### PR TITLE
Use presiding policy from config while enabling ProtectPaths

### DIFF
--- a/Fhi.HelseId/Fhi.HelseId.csproj
+++ b/Fhi.HelseId/Fhi.HelseId.csproj
@@ -6,7 +6,7 @@
     <LangVersion>8</LangVersion>
     <Configurations>Debug;Release</Configurations>
     <id>Fhi.HelseId</id>
-    <Version>2.0.0-beta.3</Version>
+    <Version>2.0.0-beta.4</Version>
     <authors>Folkehelseinstituttet (FHI), Nasjonalt Helsenett (NHN)</authors>
     <projectUrl>https://github.com/folkehelseinstituttet/Fhi.HelseId</projectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Fhi.HelseId/Web/ExtensionMethods/ServiceCollectionExtensions.cs
+++ b/Fhi.HelseId/Web/ExtensionMethods/ServiceCollectionExtensions.cs
@@ -164,7 +164,7 @@ namespace Fhi.HelseId.Web.ExtensionMethods
         private static string DeterminePresidingPolicy(IHelseIdWebKonfigurasjon helseIdWebKonfigurasjon, IHprFeatureFlags hprFeatureFlags)
             => new []
             {
-                new { PolicyActive = hprFeatureFlags.UseHprPolicy, Policy = Policies.GodkjentHprKategoriPolicy},
+                new { PolicyActive = helseIdWebKonfigurasjon.UseHprNumber && hprFeatureFlags.UseHprPolicy, Policy = Policies.GodkjentHprKategoriPolicy},
                 new { PolicyActive = helseIdWebKonfigurasjon.UseHprNumber, Policy = Policies.HprNummer },
                 new { PolicyActive = true, Policy = Policies.HidAuthenticated }
             }

--- a/Fhi.HelseId/Web/ExtensionMethods/ServiceCollectionExtensions.cs
+++ b/Fhi.HelseId/Web/ExtensionMethods/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
+using System.Runtime.InteropServices;
 using Fhi.HelseId.Common.Identity;
 using Fhi.HelseId.Web.Hpr;
 using Fhi.HelseId.Web.Infrastructure.AutomaticTokenManagement;
@@ -154,20 +155,20 @@ namespace Fhi.HelseId.Web.ExtensionMethods
 
 
         /// <summary>
-        /// Determine the presiding policy from configuratin.
+        /// Determine the presiding policy from configuration.
         /// Will return Policies.HidAuthenticated if no other policies are configured.
         /// </summary>
         /// <param name="helseIdWebKonfigurasjon"></param>
         /// <param name="hprFeatureFlags"></param>
         /// <returns></returns>
         private static string DeterminePresidingPolicy(IHelseIdWebKonfigurasjon helseIdWebKonfigurasjon, IHprFeatureFlags hprFeatureFlags)
-        {
-            var presidingPolicyCollection = new List<KeyValuePair<bool, string>>();
-            presidingPolicyCollection.Add(new KeyValuePair<bool, string>(hprFeatureFlags.UseHprPolicy, Policies.GodkjentHprKategoriPolicy));
-            presidingPolicyCollection.Add(new KeyValuePair<bool, string>(helseIdWebKonfigurasjon.UseHprNumber, Policies.HprNummer));
-            presidingPolicyCollection.Add(new KeyValuePair<bool, string>(true, Policies.HidAuthenticated));
-            return presidingPolicyCollection.First(p => p.Key == true).Value;
-        }
-
+            => new []
+            {
+                new { PolicyActive = hprFeatureFlags.UseHprPolicy, Policy = Policies.GodkjentHprKategoriPolicy},
+                new { PolicyActive = helseIdWebKonfigurasjon.UseHprNumber, Policy = Policies.HprNummer },
+                new { PolicyActive = true, Policy = Policies.HidAuthenticated }
+            }
+            .ToList()
+            .First(p => p.PolicyActive).Policy;
     }
 }


### PR DESCRIPTION
Full disclosure: no tests have been written to support this change.
Functionality was tested by hand in a local project, toggling all HPR features on/off respectively, using a HelseId testperson and adding/subtracting godkjenninger to the GodkjenteHprKategoriListe. 