### PR TITLE
Add the Altinn delegation lookup service and tests 

### DIFF
--- a/Fhi.HelseId.Tests/Altinn/AltinnServiceOwnerClientTests.cs
+++ b/Fhi.HelseId.Tests/Altinn/AltinnServiceOwnerClientTests.cs
@@ -1,0 +1,145 @@
+﻿using Fhi.HelseId.Altinn;
+using NUnit.Framework;
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fhi.HelseId.Tests.Altinn
+{
+    [Ignore("Requires setup")]
+    public class AltinnServiceOwnerClientTests
+    {
+        // Service URI and API key for Altinn
+        const string ServiceUri = "https://tt02.altinn.no/api/serviceowner/";
+        const string ApiKey = "";
+        // Service code and service edition code for the service to use during testing of rights/reportees
+        const string ServiceCode = "";
+        const int ServiceEditionCode = 1;
+        
+        // This PID here must be delegated rights to the service above for the organization below
+        const string Pid = "";
+        const string Organization = "";
+
+        // Store name, location and thumbprint for the enterprise certificate to use during testing
+        const string CertificateStoreName = "My";
+        const string CertificateLocation = "CurrentUser";
+        const string CertificateThumbprint = "";
+
+#pragma warning disable
+        private AltinnServiceOwnerClient serviceClient;
+
+        [SetUp]
+        public void SetUp() 
+        {
+            var options = new AltinnOptions
+            {
+                AuthenticationCertificateStoreName = Enum.Parse<StoreName>(CertificateStoreName),
+                AuthenticationCertificateLocation = Enum.Parse<StoreLocation>(CertificateLocation),
+                AuthenticationCertificateThumbprint = CertificateThumbprint,
+                ServiceOwnerServiceUri = ServiceUri,
+                ServiceOwnerApiKey = ApiKey
+            };
+
+            var httpClient = new HttpClient(options.CreateHttpMessageHandler());
+            options.ConfigureHttpClient(httpClient);
+
+            serviceClient = new AltinnServiceOwnerClient(httpClient);
+        }
+
+        [Test]
+        public async Task SubUnitsExist()
+        {
+            var subUnits = serviceClient.GetOrganizationsOfTypes(CancellationToken.None, "BEDR", "AAFY");
+            Assert.NotNull(await subUnits.FirstOrDefaultAsync());
+        }
+
+        [Test]
+        public async Task UnitsExist()
+        {
+            var subUnits = serviceClient.GetOrganizationsNotOfTypes(CancellationToken.None, "BEDR", "AAFY");
+            Assert.NotNull(await subUnits.FirstOrDefaultAsync());
+        }
+
+        [Test]
+        public async Task KnownOrganizationIsPresent()
+        {
+            var organization = await serviceClient.GetOrganization(Organization);
+            Assert.NotNull(organization);
+        }
+
+        [Test]
+        public async Task MunicipalitiesExist()
+        {
+            var municipalities = serviceClient.GetOrganizationsOfTypes(CancellationToken.None, "KOMM");
+            Assert.NotNull(await municipalities.FirstOrDefaultAsync());
+        }
+
+        [Test]
+        public async Task KnownDelegationIsPresent()
+        {
+            var hasDelegation = await serviceClient.HasDelegation(Pid, Organization, ServiceCode, ServiceEditionCode);
+            Assert.True(hasDelegation);
+        }
+
+        [Test]
+        public async Task KnownReporteesArePresent()
+        {
+            var reportees = serviceClient.GetReportees(Pid, ServiceCode, ServiceEditionCode);
+            Assert.NotNull(await reportees.FirstOrDefaultAsync());
+        }
+
+        [Test]
+        public async Task RightsAreRetrievedForKnownSubjectAndReportee()
+        {
+            var rights = serviceClient.GetRights(Pid, Organization);
+            var any = await rights.AnyAsync();
+            Assert.True(any);
+        }
+
+        [Test]
+        public async Task PagingWorksForKnownReportees()
+        {
+            var both = await serviceClient.GetReportees(Pid, ServiceCode, ServiceEditionCode, 0, 2);
+            var first = await serviceClient.GetReportees(Pid, ServiceCode, ServiceEditionCode, 0, 1);
+            var second = await serviceClient.GetReportees(Pid, ServiceCode, ServiceEditionCode, 1, 1);
+
+            Assert.NotNull(both);
+            Assert.AreEqual(2, both!.Length);
+            Assert.NotNull(first.Single());
+            Assert.NotNull(second.Single());
+
+            var firstReporteeFromBoth = both[0];
+            var secondReporteeFromBoth = both[1];
+            var firstReporteeAlone = first![0];
+            var secondReporteeAlone = second![0];
+
+            Assert.AreNotEqual(firstReporteeAlone.Name, secondReporteeAlone.Name);
+            Assert.AreEqual(firstReporteeFromBoth.Name, firstReporteeAlone.Name);
+            Assert.AreEqual(secondReporteeFromBoth.Name, secondReporteeAlone.Name);
+        }
+
+        [Test]
+        public async Task PagingWorksForKnownRights()
+        {
+            var both = await serviceClient.GetRights(Pid, Organization, 0, 2);
+            var first = await serviceClient.GetRights(Pid, Organization, 0, 1);
+            var second = await serviceClient.GetRights(Pid, Organization, 1, 1);
+
+            Assert.AreEqual(2, both.Rights.Length);
+            Assert.NotNull(first.Rights.Single());
+            Assert.NotNull(second.Rights.Single());
+
+            var firstRightFromBoth = both.Rights[0];
+            var secondRightFromBoth = both.Rights[1];
+            var firstRightAlone = first.Rights[0];
+            var secondRightAlone = second.Rights[0];
+
+            Assert.AreNotEqual(firstRightAlone.RightID, secondRightAlone.RightID);
+            Assert.AreEqual(firstRightFromBoth.RightID, firstRightAlone.RightID);
+            Assert.AreEqual(secondRightFromBoth.RightID, secondRightAlone.RightID);
+        }
+    }
+}

--- a/Fhi.HelseId/Altinn/AltinnException.cs
+++ b/Fhi.HelseId/Altinn/AltinnException.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Fhi.HelseId.Altinn
+{
+    [Serializable]
+    public class AltinnException : Exception
+    {
+        public AltinnException()
+        {
+        }
+
+        public AltinnException(string? message) : base(message)
+        {
+        }
+
+        public AltinnException(string? message, Exception? innerException) : base(message, innerException)
+        {
+        }
+
+        protected AltinnException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/Fhi.HelseId/Altinn/AltinnOptions.cs
+++ b/Fhi.HelseId/Altinn/AltinnOptions.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.Net.Http;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Fhi.HelseId.Altinn
+{
+    /// <summary>
+    /// Configuration options for <see cref="AltinnServiceOwnerClient"/>.
+    /// </summary>
+    public class AltinnOptions
+    {
+        /// <summary>
+        /// Gets or sets the store in which the certificate to use for TLS client authentication against Altinn is located.         
+        /// </summary>
+        /// <remarks>
+        /// Use this in conjunction with <see cref="AuthenticationCertificateStoreName"/> and 
+        /// <see cref="AuthenticationCertificateThumbprint"/> if the TLS 
+        /// client certificate is located in one of the Windows certificate stores.
+        /// </remarks>
+        /// <seealso cref="AuthenticationCertificatePath"/>
+        /// <seealso cref="AuthenticationCertificatePassword"/>
+        public StoreLocation AuthenticationCertificateLocation { get; set; } = StoreLocation.CurrentUser;
+
+        /// <summary>
+        /// Gets or sets the store in which the certificate to use for TLS client authentication against Altinn is located.         
+        /// </summary>
+        /// <remarks>
+        /// Use this in conjunction with <see cref="AuthenticationCertificateLocation"/> and 
+        /// <see cref="AuthenticationCertificateThumbprint"/> if the TLS 
+        /// client certificate is located in one of the Windows certificate stores.
+        /// </remarks>
+        /// <seealso cref="AuthenticationCertificatePath"/>
+        /// <seealso cref="AuthenticationCertificatePassword"/>
+        public StoreName AuthenticationCertificateStoreName { get; set; } = StoreName.My;
+
+        /// <summary>
+        /// Gets or sets the thumbprint for the TLS client authentication to use against Altinn.         
+        /// </summary>
+        /// <remarks>
+        /// Use this in conjunction with <see cref="AuthenticationCertificateLocation"/> and 
+        /// <see cref="AuthenticationCertificateStoreName"/> if the TLS 
+        /// client certificate is located in one of the Windows certificate stores.
+        /// </remarks>
+        /// <seealso cref="AuthenticationCertificatePath"/>
+        /// <seealso cref="AuthenticationCertificatePassword"/>
+        public string? AuthenticationCertificateThumbprint { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to a file containing the TLS client authentication certificate 
+        /// to use against Altinn.
+        /// </summary>
+        /// <remarks>
+        /// Use this in conjuction with <see cref="AuthenticationCertificatePassword"/> if the TLS
+        /// client certificate is located in a file.
+        /// </remarks>
+        /// <seealso cref="AuthenticationCertificateLocation"/>
+        /// <seealso cref="AuthenticationCertificateStoreName"/>
+        /// <seealso cref="AuthenticationCertificateThumbprint"/>
+        public string? AuthenticationCertificatePath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the password protecting the file containing the TLS client authentication certificate 
+        /// to use against Altinn.
+        /// </summary>
+        /// <remarks>
+        /// Use this in conjuction with <see cref="AuthenticationCertificatePath"/> if the TLS
+        /// client certificate is located in a file.
+        /// </remarks>
+        /// <seealso cref="AuthenticationCertificateLocation"/>
+        /// <seealso cref="AuthenticationCertificateStoreName"/>
+        /// <seealso cref="AuthenticationCertificateThumbprint"/>
+        public string? AuthenticationCertificatePassword { get; set; }
+
+        /// <summary>
+        /// Gets or sets the base URI for the ServiceOwner API endpoints, e.g. https://tt02.altinn.no/api/serviceowner/.
+        /// </summary>
+        [Required]
+        public string ServiceOwnerServiceUri { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the API key to use when calling the ServiceOwner API.
+        /// </summary>
+        [Required]
+        public string ServiceOwnerApiKey { get; set; } = string.Empty;
+
+        public void ConfigureHttpClient(HttpClient httpClient)
+        {
+            httpClient.BaseAddress = new Uri(ServiceOwnerServiceUri);
+            httpClient.DefaultRequestHeaders.Accept.Clear();
+            httpClient.DefaultRequestHeaders.Accept.ParseAdd("application/json");
+            httpClient.DefaultRequestHeaders.Add("ApiKey", ServiceOwnerApiKey);
+        }
+
+        public HttpMessageHandler CreateHttpMessageHandler()
+        {
+            var cert = FindCertificate();
+            var clientHandler = new HttpClientHandler { ClientCertificateOptions = ClientCertificateOption.Manual };
+            clientHandler.ClientCertificates.Add(cert);
+            return clientHandler;
+        }
+
+        private X509Certificate2 FindCertificate()
+        {
+            if (!string.IsNullOrWhiteSpace(AuthenticationCertificatePath))
+            {
+                return new X509Certificate2(AuthenticationCertificatePath, AuthenticationCertificatePassword);
+            }
+
+            if (!string.IsNullOrWhiteSpace(AuthenticationCertificateThumbprint))
+            {
+                var store = new X509Store(AuthenticationCertificateStoreName, AuthenticationCertificateLocation);
+                store.Open(OpenFlags.ReadOnly);
+
+                var certs = store.Certificates.Find(
+                    X509FindType.FindByThumbprint,
+                    AuthenticationCertificateThumbprint,
+                    true
+                );
+
+                if (certs.Count <= 0)
+                {
+                    throw new Exception(
+                        $"Could not find the enterprise certificate with thumbprint {AuthenticationCertificateThumbprint}"
+                    );
+                }
+
+                return certs[0];
+            }
+
+            throw new InvalidOperationException(
+                $"Either {nameof(AuthenticationCertificatePath)} or {nameof(AuthenticationCertificateThumbprint)} must be set"
+            );
+        }
+    }
+}

--- a/Fhi.HelseId/Altinn/AltinnOptions.cs
+++ b/Fhi.HelseId/Altinn/AltinnOptions.cs
@@ -120,7 +120,7 @@ namespace Fhi.HelseId.Altinn
 
                 if (certs.Count <= 0)
                 {
-                    throw new Exception(
+                    throw new AltinnException(
                         $"Could not find the enterprise certificate with thumbprint {AuthenticationCertificateThumbprint}"
                     );
                 }
@@ -128,7 +128,7 @@ namespace Fhi.HelseId.Altinn
                 return certs[0];
             }
 
-            throw new InvalidOperationException(
+            throw new AltinnException(
                 $"Either {nameof(AuthenticationCertificatePath)} or {nameof(AuthenticationCertificateThumbprint)} must be set"
             );
         }

--- a/Fhi.HelseId/Altinn/AltinnServiceOwnerClient.cs
+++ b/Fhi.HelseId/Altinn/AltinnServiceOwnerClient.cs
@@ -1,0 +1,189 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fhi.HelseId.Altinn
+{
+    public class AltinnServiceOwnerClient : IAltinnServiceOwnerClient
+    {
+        private readonly HttpClient httpClient;
+
+        public AltinnServiceOwnerClient(HttpClient httpClient)
+        {
+            this.httpClient = httpClient;
+        }
+
+        private async Task<HttpResponseMessage> GetWithForceEIAuthentication(string endpoint, CancellationToken cancellationToken = default, params string[] queryParams)
+        {
+            // Build and send a request, guaranteeing that the ForceEIAuthentication is sent as the first query parameter
+
+            const string firstQueryParameter = "?ForceEIAuthentication"; // Force Enterprise Identified Authentication, meaning we authenticate using an Enterprise Certificate
+
+            var baseUri = new UriBuilder(httpClient.BaseAddress + endpoint);
+            // If the query length is 1 we assume the query string is only ? (or garbage) and can be replaced.
+            // Otherwise we keep whatever is beyond the ?.
+            baseUri.Query = baseUri.Query?.Length > 1 ? firstQueryParameter + "&" + baseUri.Query.Substring(1) : firstQueryParameter;
+
+            if (queryParams != null && queryParams.Length > 0)
+            {
+                baseUri.Query += "&" + string.Join('&', queryParams);
+            }
+
+            var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Get,
+                RequestUri = baseUri.Uri
+            };
+
+            return await httpClient.SendAsync(request, cancellationToken);
+        }
+
+        public async IAsyncEnumerable<Organization> GetOrganizations(IEnumerable<string> orgNumbers, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            foreach (var orgNo in orgNumbers)
+            {
+                var org = await GetOrganization(orgNo, cancellationToken);
+                if (org != null)
+                {
+                    yield return org;
+                }
+            }
+        }
+
+        public async IAsyncEnumerable<Organization> GetOrganizationsOfTypes([EnumeratorCancellation] CancellationToken cancellationToken = default, params string[] types)
+        {
+            int skip = 0, take = 1000, taken = 1000;
+
+            while (taken > 0)
+            {
+                var orgs = await GetOrganizationsOfTypes(types, skip, take, cancellationToken);
+                taken = orgs.Length;
+                skip += taken;
+                foreach (var org in orgs)
+                {
+                    yield return org;
+                }
+            }
+        }
+
+        private async Task<Organization[]> GetOrganizationsOfTypes(string[] types, int skip, int take, CancellationToken cancellationToken = default)
+        {
+            var filter = string.Join(" or ", types.Select(type => $"Type eq '{type}'"));
+            using var response = await GetWithForceEIAuthentication("organizations", cancellationToken, $"$filter={filter}", $"$skip={skip}", $"$top={take}");
+            return await DeserializeIfSuccessful<Organization[]>(response);
+        }
+
+        public async IAsyncEnumerable<Organization> GetOrganizationsNotOfTypes([EnumeratorCancellation] CancellationToken cancellationToken = default, params string[] types)
+        {
+            int skip = 0, take = 1000, taken = 1000;
+
+            while (taken > 0)
+            {
+                var orgs = await GetOrganizationsNotOfTypes(types, skip, take, cancellationToken);
+                taken = orgs.Length;
+                skip += taken;
+                foreach (var org in orgs)
+                {
+                    yield return org;
+                }
+            }
+        }
+
+        private async Task<Organization[]> GetOrganizationsNotOfTypes(string[] types, int skip, int take, CancellationToken cancellationToken = default)
+        {
+            var filter = string.Join(" and ", types.Select(type => $"Type ne '{type}'"));
+            using var response = await GetWithForceEIAuthentication("organizations", cancellationToken, $"$filter={filter}", $"$skip={skip}", $"$top={take}");
+            return await DeserializeIfSuccessful<Organization[]>(response);
+        }
+
+        public async Task<Organization?> GetOrganization(string orgNo, CancellationToken cancellation = default)
+        {
+            using var response = await GetWithForceEIAuthentication($"organizations/{orgNo}", cancellation);
+            if (response.StatusCode == HttpStatusCode.BadRequest && response.ReasonPhrase == $"Invalid organization number: {orgNo}")
+            {
+                return null;
+            }
+
+            return await DeserializeIfSuccessful<Organization>(response);
+        }
+        public async IAsyncEnumerable<Reportee> GetReportees(string subject, string serviceCode, int serviceEditionCode, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            int skip = 0, take = 1000, taken = 1000;
+
+            while (taken > 0)
+            {
+                var reportees = await GetReportees(subject, serviceCode, serviceEditionCode, skip, take, cancellationToken);
+                if (reportees == null)
+                {
+                    yield break;
+                }
+
+                taken = reportees.Length;
+                skip += taken;
+                foreach (var reportee in reportees)
+                {
+                    yield return reportee;
+                }
+            }
+        }
+
+        public async Task<Reportee[]?> GetReportees(string subject, string serviceCode, int serviceEditionCode, int skip, int take, CancellationToken cancellationToken = default)
+        {
+            using var response = await GetWithForceEIAuthentication($"reportees", cancellationToken, $"subject={subject}", $"serviceCode={serviceCode}", $"serviceEdition={serviceEditionCode}", $"$skip={skip}", $"$top={take}");
+
+            if (response.StatusCode == HttpStatusCode.BadRequest && response.ReasonPhrase == $"Invalid social security number: {subject}")
+            {
+                return null;
+            }
+
+            var reportees = await DeserializeIfSuccessful<Reportee[]>(response);
+            return reportees;
+        }
+
+        public async IAsyncEnumerable<Right> GetRights(string subject, string reportee, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            int skip = 0, take = 50, taken = 50;
+
+            while (taken > 0)
+            {
+                var rights = await GetRights(subject, reportee, skip, take, cancellationToken);
+                taken = rights.Rights.Length;
+                skip += taken;
+                foreach (var right in rights.Rights)
+                {
+                    yield return right;
+                }
+            }
+        }
+
+        public async Task<RightsResponse> GetRights(string subject, string reportee, int skip, int take, CancellationToken cancellationToken = default)
+        {
+            using var response = await GetWithForceEIAuthentication("authorization/rights", cancellationToken, $"subject={subject}", $"reportee={reportee}", $"$skip={skip}", $"$top={take}");
+            var rights = await DeserializeIfSuccessful<RightsResponse>(response);
+            return rights;
+        }
+
+        private static async Task<T> DeserializeIfSuccessful<T>(HttpResponseMessage response)
+        {
+            response.EnsureSuccessStatusCode();
+
+            var content = await response.Content.ReadAsStreamAsync();
+            var instance = await JsonSerializer.DeserializeAsync<T>(content);
+            return instance;
+        }
+
+        public async Task<bool> HasDelegation(string subject, string reportee, string serviceCode, int serviceEditionCode, CancellationToken cancellationToken = default)
+        {
+            var rights = GetRights(subject, reportee, cancellationToken);
+
+            // Don't care about the Altinn rights read/write/archiveread/archivedelete - as long as there is one, we consider it granted
+            return await rights.AnyAsync(r => r.ServiceCode == serviceCode && r.ServiceEditionCode == serviceEditionCode); 
+        }
+    }
+}

--- a/Fhi.HelseId/Altinn/AltinnServiceOwnerClient.cs
+++ b/Fhi.HelseId/Altinn/AltinnServiceOwnerClient.cs
@@ -13,7 +13,7 @@ namespace Fhi.HelseId.Altinn
     public class AltinnServiceOwnerClient : IAltinnServiceOwnerClient
     {
         private readonly HttpClient httpClient;
-
+        
         public AltinnServiceOwnerClient(HttpClient httpClient)
         {
             this.httpClient = httpClient;
@@ -58,9 +58,11 @@ namespace Fhi.HelseId.Altinn
 
         public IAsyncEnumerable<Organization> GetOrganizationsOfTypes(CancellationToken cancellationToken = default, params string[] types)
         {
+            const int take = 1000; // Maximum page size for organization responses in Altinn
+
             return GetAllThroughPaging(
                 async (skip, take) => await GetOrganizationsOfTypes(types, skip, take, cancellationToken),
-                1000);
+                take);
         }
 
         private async Task<Organization[]> GetOrganizationsOfTypes(string[] types, int skip, int take, CancellationToken cancellationToken = default)
@@ -72,9 +74,11 @@ namespace Fhi.HelseId.Altinn
 
         public IAsyncEnumerable<Organization> GetOrganizationsNotOfTypes(CancellationToken cancellationToken = default, params string[] types)
         {
+            const int take = 1000; // Maximum page size for organization responses in Altinn
+
             return GetAllThroughPaging(
                    async (skip, take) => await GetOrganizationsNotOfTypes(types, skip, take, cancellationToken),
-                   1000);
+                   take);
         }
 
         private async Task<Organization[]> GetOrganizationsNotOfTypes(string[] types, int skip, int take, CancellationToken cancellationToken = default)
@@ -96,9 +100,11 @@ namespace Fhi.HelseId.Altinn
         }
         public IAsyncEnumerable<Reportee> GetReportees(string subject, string serviceCode, int serviceEditionCode, CancellationToken cancellationToken = default)
         {
+            const int take = 1000; // Maximum page size for reportee responses in Altinn
+
             return GetAllThroughPaging(
                       async (skip, take) => await GetReportees(subject, serviceCode, serviceEditionCode, skip, take, cancellationToken),
-                      1000);
+                      take);
         }
 
         public async Task<Reportee[]?> GetReportees(string subject, string serviceCode, int serviceEditionCode, int skip, int take, CancellationToken cancellationToken = default)
@@ -116,9 +122,11 @@ namespace Fhi.HelseId.Altinn
 
         public IAsyncEnumerable<Right> GetRights(string subject, string reportee, CancellationToken cancellationToken = default)
         {
+            const int take = 50; // Maximum page size for rights responses in Altinn
+            
             return GetAllThroughPaging(
                       async (skip, take) => (await GetRights(subject, reportee, skip, take, cancellationToken)).Rights,
-                      50);
+                      take);
         }
 
         public async Task<RightsResponse> GetRights(string subject, string reportee, int skip, int take, CancellationToken cancellationToken = default)
@@ -165,8 +173,5 @@ namespace Fhi.HelseId.Altinn
             }
             while (page.Length > 0);
         }
-
     }
-
-
 }

--- a/Fhi.HelseId/Altinn/IAltinnServiceOwnerClient.cs
+++ b/Fhi.HelseId/Altinn/IAltinnServiceOwnerClient.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fhi.HelseId.Altinn
+{
+    public interface IAltinnServiceOwnerClient
+    {
+        IAsyncEnumerable<Organization> GetOrganizations(IEnumerable<string> orgNumbers, CancellationToken cancellationToken = default);
+        IAsyncEnumerable<Organization> GetOrganizationsOfTypes(CancellationToken cancellationToken = default, params string[] organizationStructureCodes);
+
+        IAsyncEnumerable<Organization> GetOrganizationsNotOfTypes(
+            CancellationToken cancellationToken = default,
+            params string[] types
+        );
+
+        Task<Organization?> GetOrganization(string orgNo, CancellationToken cancellationToken = default);
+        IAsyncEnumerable<Reportee> GetReportees(string subject, string serviceCode, int serviceEditionCode, CancellationToken cancellationToken = default);
+        IAsyncEnumerable<Right> GetRights(string subject, string reportee, CancellationToken cancellationToken = default);
+        Task<Reportee[]?> GetReportees(string subject, string serviceCode, int serviceEditionCode, int skip, int take, CancellationToken cancellationToken = default);
+        Task<RightsResponse> GetRights(string subject, string reportee, int skip, int take, CancellationToken cancellationToken = default);
+        Task<bool> HasDelegation(string subject, string reportee, string serviceCode, int serviceEditionCode, CancellationToken cancellationToken = default);
+    }
+
+}

--- a/Fhi.HelseId/Altinn/IServiceCollectionExtensions.cs
+++ b/Fhi.HelseId/Altinn/IServiceCollectionExtensions.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Fhi.HelseId.Altinn
+{
+    public static class IServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Set up an <see cref="IAltinnServiceOwnerClient"/> for dependency injection using the provided <see cref="AltinnOptions"/>.
+        /// </summary>
+        /// <param name="services">The service collection instance to add the <see cref="IAltinnServiceOwnerClient" /> to.</param>
+        /// <param name="options">The <see cref="AltinnOptions" /> to use.</param>
+        public static void ConfigureAltinnServiceClient(this IServiceCollection services, AltinnOptions options)
+        {
+            services
+                .AddHttpClient<IAltinnServiceOwnerClient, AltinnServiceOwnerClient>(options.ConfigureHttpClient)
+                .ConfigurePrimaryHttpMessageHandler(options.CreateHttpMessageHandler);
+        }
+    }
+}

--- a/Fhi.HelseId/Altinn/Organization.cs
+++ b/Fhi.HelseId/Altinn/Organization.cs
@@ -1,0 +1,12 @@
+﻿namespace Fhi.HelseId.Altinn
+{
+    public class Organization
+    {
+        public string? Name { get; set; }
+        public string? OrganizationNumber { get; set; }
+        public string? Type { get; set; }
+        public string? LastChanged { get; set; }
+        public string? LastConfirmed { get; set; }
+    }
+
+}

--- a/Fhi.HelseId/Altinn/Reportee.cs
+++ b/Fhi.HelseId/Altinn/Reportee.cs
@@ -1,0 +1,14 @@
+﻿namespace Fhi.HelseId.Altinn
+{
+    public class Reportee
+    {
+        public string? Name { get; set; }
+        public string? Type { get; set; }
+        public string? OrganizationNumber { get; set; }
+        public string? ParentOrganizationNumber { get; set; }
+        public string? SocialSecurityNumber { get; set; }
+        public string? OrganizationForm { get; set; }
+        public string? Status { get; set; }
+    }
+
+}

--- a/Fhi.HelseId/Altinn/Right.cs
+++ b/Fhi.HelseId/Altinn/Right.cs
@@ -1,0 +1,14 @@
+﻿namespace Fhi.HelseId.Altinn
+{
+    public class Right
+    {
+        public int RightID { get; set; }
+        public string? RightType { get; set; }
+        public string? ServiceCode { get; set; }
+        public int ServiceEditionCode { get; set; }
+        public string? Action { get; set; }
+        public string? RightSourceType { get; set; }
+        public bool IsDelegatable { get; set; }
+    }
+
+}

--- a/Fhi.HelseId/Altinn/RightsResponse.cs
+++ b/Fhi.HelseId/Altinn/RightsResponse.cs
@@ -1,0 +1,11 @@
+﻿namespace Fhi.HelseId.Altinn
+{
+    public class RightsResponse
+    {
+        public Subject? Subject { get; set; }
+        public Reportee? Reportee { get; set; }
+
+        public Right[] Rights { get; set; } = new Right[0];
+    }
+
+}

--- a/Fhi.HelseId/Altinn/Subject.cs
+++ b/Fhi.HelseId/Altinn/Subject.cs
@@ -1,0 +1,10 @@
+﻿namespace Fhi.HelseId.Altinn
+{
+    public class Subject
+    {
+        public string? Name { get; set; }
+        public string? Type { get; set; }
+        public string? SocialSecurityNumber { get; set; }
+    }
+
+}

--- a/Fhi.HelseId/Fhi.HelseId.csproj
+++ b/Fhi.HelseId/Fhi.HelseId.csproj
@@ -40,6 +40,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.9" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.9" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Analyzers" Version="3.1.9" />
+    <PackageReference Include="System.Linq.Async" Version="4.1.1" />
     <PackageReference Include="System.ServiceModel.Http" Version="4.7.0" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.7.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />


### PR DESCRIPTION
Add the Altinn delegation lookup service, which facilitates lookups against Altinn and can be used for checking whether a person is delegated a certain right to a service for an organization.

Tests are also added, but are ignored for now as we need to agree upon how to handle local setup (if we want tests to run locally at all). 