### PR TITLE
Include symbols when pushing nuget package

### DIFF
--- a/.github/workflows/Fhi.HelseId.Nuget.yml
+++ b/.github/workflows/Fhi.HelseId.Nuget.yml
@@ -44,4 +44,4 @@ jobs:
           NUGET_SOURCE: https://api.nuget.org
 
           # Flag to toggle pushing symbols along with nuget package to the server, disabled by default
-          # INCLUDE_SYMBOLS: false
+          INCLUDE_SYMBOLS: true

--- a/Fhi.HelseId/Fhi.HelseId.csproj
+++ b/Fhi.HelseId/Fhi.HelseId.csproj
@@ -6,7 +6,7 @@
     <LangVersion>8</LangVersion>
     <Configurations>Debug;Release</Configurations>
     <id>Fhi.HelseId</id>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <authors>Folkehelseinstituttet (FHI), Nasjonalt Helsenett (NHN)</authors>
     <projectUrl>https://github.com/folkehelseinstituttet/Fhi.HelseId</projectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Include debug symbols when pushing nuget-package.
Should be very useful for those depending on symbols being available in their debug/unit testing process.