### PR TITLE
Added RewriteRedirectUriHttps-config to rewrite Redirect Uri

### DIFF
--- a/Fhi.HelseId.Tests/HelseIdWebKonfigurasjonTests.cs
+++ b/Fhi.HelseId.Tests/HelseIdWebKonfigurasjonTests.cs
@@ -40,20 +40,20 @@ namespace Fhi.HelseId.Tests
             Assert.That(sut, Is.Not.Null, $"Can't load {ConfigFilename}");
             Assert.Multiple(() =>
             {
-                Assert.That(sut?.Authority, Does.Contain("helseid-sts"), "1");
-                Assert.That(sut?.AuthUse, Is.True, "2");
-                Assert.That(sut?.UseHttps, Is.True, "3");
-                Assert.That(sut?.ClientId.Length, Is.GreaterThan(1));
-                Assert.That(sut?.AllScopes.Count, Is.GreaterThanOrEqualTo(1), "4");
-                Assert.That(sut?.Apis.Length, Is.EqualTo(1), "5");
+                Assert.That(sut!.Authority, Does.Contain("helseid-sts"), "1");
+                Assert.That(sut!.AuthUse, Is.True, "2");
+                Assert.That(sut!.UseHttps, Is.True, "3");
+                Assert.That(sut!.ClientId.Length, Is.GreaterThan(1));
+                Assert.That(sut!.AllScopes.Count, Is.GreaterThanOrEqualTo(1), "4");
+                Assert.That(sut!.Apis.Length, Is.EqualTo(1), "5");
             });
             var api = sut?.Apis[0];
             Assert.That(api, Is.Not.Null);
             Assert.Multiple(() =>
             {
-                Assert.That(api.Name, Is.EqualTo("Personoppslag"));
-                Assert.That(api.Url, Is.EqualTo("https://test-personoppslag.fhi.no"));
-                Assert.That(api.Scope, Is.EqualTo("fhi:personoppslag/api"));
+                Assert.That(api!.Name, Is.EqualTo("Personoppslag"));
+                Assert.That(api!.Url, Is.EqualTo("https://test-personoppslag.fhi.no"));
+                Assert.That(api!.Scope, Is.EqualTo("fhi:personoppslag/api"));
             });
         }
     }

--- a/Fhi.HelseId.Tests/HelseIdWebKonfigurasjonTests.cs
+++ b/Fhi.HelseId.Tests/HelseIdWebKonfigurasjonTests.cs
@@ -48,6 +48,7 @@ namespace Fhi.HelseId.Tests
                 Assert.That(sut?.Apis.Length, Is.EqualTo(1), "5");
             });
             var api = sut?.Apis[0];
+            Assert.That(api, Is.Not.Null);
             Assert.Multiple(() =>
             {
                 Assert.That(api.Name, Is.EqualTo("Personoppslag"));

--- a/Fhi.HelseId/Common/HelseIdClientKonfigurasjon.cs
+++ b/Fhi.HelseId/Common/HelseIdClientKonfigurasjon.cs
@@ -8,6 +8,7 @@ namespace Fhi.HelseId.Common
     {
         bool AuthUse { get; set; }
         bool UseHttps { get; set; }
+        bool RewriteRedirectUriHttps { get; set; }
         string Authority { get; set; }
         string ClientId { get; set; }
         string ClientSecret { get; set; }
@@ -23,6 +24,7 @@ namespace Fhi.HelseId.Common
         protected List<string>? AllTheScopes { get; private set; }
         public bool AuthUse { get; set; } = true;
         public bool UseHttps { get; set; } = true;
+        public bool RewriteRedirectUriHttps { get; set; } = false;
         public string Authority { get; set; } = "";
         public string ClientId { get; set; } = "";
         public string ClientSecret { get; set; } = "";

--- a/Fhi.HelseId/Web/ExtensionMethods/HelseIdExtensions.cs
+++ b/Fhi.HelseId/Web/ExtensionMethods/HelseIdExtensions.cs
@@ -69,6 +69,16 @@ namespace Fhi.HelseId.Web.ExtensionMethods
                     ctx.ProtocolMessage.AcrValues = acrValues;
                 }
 
+                if (configAuth.RewriteRedirectUriHttps)
+                {
+                    // Rewrite Redirect Uri to use https in case e.g. running from container
+                    var builder = new UriBuilder(ctx.ProtocolMessage.RedirectUri)
+                    {
+                        Scheme = "https"
+                    };
+                    ctx.ProtocolMessage.RedirectUri = builder.ToString();
+                }
+
                 return Task.CompletedTask;
             };
 

--- a/Fhi.HelseId/Web/ExtensionMethods/ServiceCollectionExtensions.cs
+++ b/Fhi.HelseId/Web/ExtensionMethods/ServiceCollectionExtensions.cs
@@ -143,7 +143,7 @@ namespace Fhi.HelseId.Web.ExtensionMethods
                     services.AddScoped<IAuthorizationHandler, HprGodkjenningAuthorizationHandler>();
             }
 
-            return (policyName, mvcBuilder);;            
+            return (policyName, mvcBuilder);        
         }
 
         public static IMvcBuilder AddHelseIdWebAuthentication(this IServiceCollection services,

--- a/Fhi.HelseId/Web/HelseIdWebKonfigurasjon.cs
+++ b/Fhi.HelseId/Web/HelseIdWebKonfigurasjon.cs
@@ -13,6 +13,7 @@ namespace Fhi.HelseId.Web
     public interface IHelseIdWebKonfigurasjon : IAutentiseringkonfigurasjon, IHelseIdHprFeatures
     {
         bool UseHttps { get; }
+        bool RewriteRedirectUriHttps { get; }
         string Authority { get; }
         string ClientId { get; }
         string ClientSecret { get; }


### PR DESCRIPTION
Added RewriteRedirectUriHttps-config to rewrite Redirect Uri to use https in case e.g. running from container

When running inside a container it will usually not use SSL-certificate and https, but encryption - SSL-certificate and https will usually be terminated through a load balancer outside of the container that will proxy the https request to http inside the container. In such cases set RewriteRedirectUriHttps to true to rewrite the Redirect Uri from http to https.