### PR TITLE
Add Port = -1 to use default port-number in UriBuilder

### DIFF
--- a/Fhi.HelseId/Web/ExtensionMethods/HelseIdExtensions.cs
+++ b/Fhi.HelseId/Web/ExtensionMethods/HelseIdExtensions.cs
@@ -74,7 +74,8 @@ namespace Fhi.HelseId.Web.ExtensionMethods
                     // Rewrite Redirect Uri to use https in case e.g. running from container
                     var builder = new UriBuilder(ctx.ProtocolMessage.RedirectUri)
                     {
-                        Scheme = "https"
+                        Scheme = "https",
+                        Port = -1
                     };
                     ctx.ProtocolMessage.RedirectUri = builder.ToString();
                 }


### PR DESCRIPTION
Setting Port = -1 will make UriBuilder use the default port for the Protocol-Scheme.

https://docs.microsoft.com/en-us/dotnet/api/system.uribuilder.port?view=net-6.0#System_UriBuilder_Port

"If the Port property is set to a value of -1, this indicates that the default port value for the protocol scheme will be used to connect to the host."