### PR TITLE
Ny versjon av Fhi.HelseId.TestSupport

### DIFF
--- a/.github/workflows/Fhi.HelseId.TestSupport.Nuget.yml
+++ b/.github/workflows/Fhi.HelseId.TestSupport.Nuget.yml
@@ -1,34 +1,47 @@
 name: Fhi.HelseId.TestSupport.Nuget
-
 on:
   push:
     branches:
       - master
-
 jobs:
   publish:
     name: Build, pack & publish
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        dotnet-version: ['6.0.x', '8.0.x']
-
     steps:
       - uses: actions/checkout@v2
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: ${{ matrix.dotnet-version }}
+          dotnet-version: '6.0.x'
 
       # Publish
       - name: Publish on version change
         id: publish_nuget
         uses: rohith/publish-nuget@v2
         with:
+          # Filepath of the project to be packaged, relative to root of repository
           PROJECT_FILE_PATH: 'Fhi.HelseId.TestSupport/Fhi.HelseId.TestSupport.csproj'
+          
+          # NuGet package id, used for version detection & defaults to project name
           PACKAGE_NAME: Fhi.HelseId.TestSupport
+          
+          # Regex pattern to extract version info in a capturing group
           VERSION_REGEX: <Version>(.*)<\/Version>
+          
+          # Useful with external providers like Nerdbank.GitVersioning, ignores VERSION_FILE_PATH & VERSION_REGEX
+          # VERSION_STATIC: 1.0.0
+
+          # Flag to toggle git tagging, enabled by default
           TAG_COMMIT: true
+
+          # Format of the git tag, [*] gets replaced with actual version
+          # TAG_FORMAT: v*
+
+          # API key to authenticate with NuGet server
           NUGET_KEY: ${{secrets.NUGET_ORG_PUSH_API_KEY_HELSEID}}
+
+          # NuGet server uri hosting the packages, defaults to https://api.nuget.org
           NUGET_SOURCE: https://api.nuget.org
+
+          # Flag to toggle pushing symbols along with nuget package to the server, disabled by default
           INCLUDE_SYMBOLS: true

--- a/Fhi.HelseId.TestSupport/Fhi.HelseId.TestSupport.csproj
+++ b/Fhi.HelseId.TestSupport/Fhi.HelseId.TestSupport.csproj
@@ -3,18 +3,18 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <Id>Fhi.HelseId.TestSupport</Id>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
     <IsPackable>true</IsPackable>
     <IsTestProject>false</IsTestProject>
     <authors>Folkehelseinstituttet (FHI), Nasjonalt Helsenett (NHN)</authors>
-    <Copyright>(c) 2021-2023 Folkehelseinstituttet (FHI), Nasjonalt Helsenett (NHN)</Copyright>
+    <Copyright>(c) 2021-2024 Folkehelseinstituttet (FHI), Nasjonalt Helsenett (NHN)</Copyright>
     <projectUrl>https://github.com/folkehelseinstituttet/Fhi.HelseId</projectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <icon>https://github.com/folkehelseinstituttet/Fhi.HelseId/images/fhi.png</icon>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageReleaseNotes>Upgrades NUnit to 4.0.1</PackageReleaseNotes>
     <PackageDescription>Base classes for testing an implementation using Fhi.HelseId</PackageDescription>
-    <PackageCopyright>Copyright ©2021-2023 Folkehelseinstituttet, Nasjonalt Helsenett NHN</PackageCopyright>
+    <PackageCopyright>Copyright ©2021-2024 Folkehelseinstituttet, Nasjonalt Helsenett NHN</PackageCopyright>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <tags>helseid, oauth</tags>
@@ -37,9 +37,9 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Fhi.HelseId" Version="5.1.0" />
+    <PackageReference Include="Fhi.HelseId" Version="5.2.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
-    <PackageReference Include="morelinq" Version="4.0.0" />
+    <PackageReference Include="morelinq" Version="4.1.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Oppdaterte Fhi.HelseId.TestSupport slik at denne støtter siste publiserte versjon av Fhi.HelseId - versjon 5.2.0. Endret tilbake yaml-fil da denne var oppdatert til å støtte versjon 5.3.0 litt for tidlig.