### PR TITLE
Prosjektene har nå referanse til Fhi.HelseId Versjon 5.*

### DIFF
--- a/Fhi.AccountController/Fhi.AuthControllers.csproj
+++ b/Fhi.AccountController/Fhi.AuthControllers.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fhi.HelseId" Version="5.1.0" />
+    <PackageReference Include="Fhi.HelseId" Version="5.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Fhi.HelseId.TestSupport/Fhi.HelseId.TestSupport.csproj
+++ b/Fhi.HelseId.TestSupport/Fhi.HelseId.TestSupport.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="#329" Version="5.*" />
+    <PackageReference Include="Fhi.HelseId" Version="5.*" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="morelinq" Version="4.1.0" />
   </ItemGroup>

--- a/Fhi.HelseId.TestSupport/Fhi.HelseId.TestSupport.csproj
+++ b/Fhi.HelseId.TestSupport/Fhi.HelseId.TestSupport.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Fhi.HelseId" Version="5.2.0" />
+    <PackageReference Include="#329" Version="5.*" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="morelinq" Version="4.1.0" />
   </ItemGroup>


### PR DESCRIPTION
Erstattet referanse til eksplisitte versjoner med referanse til versjon 5.*