### PR TITLE
Endret til å bare bygge 1 gang

### DIFF
--- a/.github/workflows/Fhi.HelseId.CI.yml
+++ b/.github/workflows/Fhi.HelseId.CI.yml
@@ -5,16 +5,16 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: windows-latest
-    strategy:
-      matrix:
-        dotnet-version: ['6.0.x', '8.0.x']  # Spesifiser nødvendige .NET SDK-versjoner her
 
     steps:
       - uses: actions/checkout@v4
-      - name: Setup dotnet ${{ matrix.dotnet-version }}
-        uses: actions/setup-dotnet@v3
+
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ matrix.dotnet-version }}
+          dotnet-version: |
+            6.0.x
+            8.0.x
 
       - name: Display dotnet version
         run: dotnet --version

--- a/.github/workflows/Fhi.HelseId.Refit.Nuget.yml
+++ b/.github/workflows/Fhi.HelseId.Refit.Nuget.yml
@@ -15,24 +15,28 @@ jobs:
   publish:
     name: Build, pack & publish
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        dotnet-version: ['6.0.x', '8.0.x']
 
     steps:
       - uses: actions/checkout@v4
         with:
             fetch-depth: 0
+
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ matrix.dotnet-version }}
+          dotnet-version: |
+            6.0.x
+            8.0.x
+
       - name: Install dependencies
         run: dotnet restore
+
       - name: Build
         run: dotnet build --configuration Release --no-restore --verbosity normal
+
       - name: Pack
         run: dotnet pack --configuration Release --no-build --output package 
+
       - name: Publish nupkg and snupkg to NuGet.org
         run: |
           foreach($file in (Get-ChildItem package -Recurse -Include *.nupkg)) {


### PR DESCRIPTION
Tidligere var det to egne trinn per framework versjon. Nå er det ett trinn som bygger begge versjonene.