### PR TITLE
Custom correlation id handler

### DIFF
--- a/Fhi.HelseId.Blazor/CorrelationIdHandler.cs
+++ b/Fhi.HelseId.Blazor/CorrelationIdHandler.cs
@@ -4,13 +4,18 @@ public class CorrelationIdHandler : DelegatingHandler
 {
     public const string CorrelationIdHeaderName = "X-Correlation-ID";
 
-    public CorrelationIdHandler()
+    private IServiceProvider _provider;
+    private HelseidRefitBuilderForBlazorOptions _options;
+
+    public CorrelationIdHandler(IServiceProvider provider, HelseidRefitBuilderForBlazorOptions options)
     {
+        _provider = provider;
+        _options = options;
     }
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        var correalationId = Guid.NewGuid().ToString();
+        var correalationId = _options.CustomCorrelationIdFunc?.Invoke(_provider) ?? Guid.NewGuid().ToString();
 
         if (request.Headers.TryGetValues(CorrelationIdHeaderName, out var values))
         {

--- a/Fhi.HelseId.Blazor/Fhi.HelseId.Blazor.csproj
+++ b/Fhi.HelseId.Blazor/Fhi.HelseId.Blazor.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <id>Fhi.HelseId.Blazor</id>
-    <Version>1.0.0-alpha.3</Version>
+    <Version>1.0.1</Version>
     <authors>Folkehelseinstituttet (FHI)</authors>
     <Copyright>©2023-2024 Folkehelseinstituttet (FHI)</Copyright>
     <projectUrl>https://github.com/folkehelseinstituttet/Fhi.HelseId</projectUrl>

--- a/Fhi.HelseId.Blazor/HelseidRefitBuilderForBlazor.cs
+++ b/Fhi.HelseId.Blazor/HelseidRefitBuilderForBlazor.cs
@@ -89,9 +89,10 @@ namespace Fhi.HelseId.Blazor
         /// Adds propagation and handling of correlation ids. You should add this before any logging-delagates. Remember to add "app.UseHeaderPropagation()" in your startup code.
         /// </summary>
         /// <returns></returns>
-        public HelseidRefitBuilderForBlazor AddCorrelationId()
+        public HelseidRefitBuilderForBlazor AddCorrelationId(Func<IServiceProvider, string>? customCorrelationIdFunc = null)
         {
             options.UseCorrelationId = true;
+            options.CustomCorrelationIdFunc = customCorrelationIdFunc;
 
             AddHandler<CorrelationIdHandler>();
 

--- a/Fhi.HelseId.Blazor/HelseidRefitBuilderForBlazorOptions.cs
+++ b/Fhi.HelseId.Blazor/HelseidRefitBuilderForBlazorOptions.cs
@@ -4,6 +4,8 @@
     {
         public bool UseCorrelationId { get; set; }
 
+        public Func<IServiceProvider, string>? CustomCorrelationIdFunc { get; set; }
+
         public bool UseLogoutUrl { get; set; } = true;
 
         public string LogOutUrl { get; set; } = "/logout";


### PR DESCRIPTION
Blazor does not propagate HttpContext-headers when creating the httpClient. We need to get it from a IUserState

```
builder.AddHelseIdForBlazor()
    .AddCorrelationId(p => p.GetRequiredService<UserState>().CorrelationId)
```