### PR TITLE
Support for HelseID token generation in Swagger

### DIFF
--- a/.github/workflows/Fhi.HelseId.Swagger.Nuget.yml
+++ b/.github/workflows/Fhi.HelseId.Swagger.Nuget.yml
@@ -1,0 +1,49 @@
+name: Fhi.HelseId.Swagger.Nuget
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'Fhi.HelseId.Swagger/**'
+defaults:
+  run:
+    shell: pwsh
+    working-directory: ./Fhi.HelseId.Swagger
+
+jobs:
+  publish:
+    name: Build, pack & publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+            fetch-depth: 0
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '6.0.x'
+      - name: Install dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --configuration Release --no-restore --verbosity normal
+      # Publish
+      # Create the NuGet package in the package folder 
+      - name: Pack
+        run: dotnet pack --configuration Release --no-build --output  package 
+  
+      # Publish the NuGet package as an artifact, so they can be used in the following jobs
+      #- uses: actions/upload-artifact@v3
+      #  with:
+      #    name: nuget
+      #    if-no-files-found: error
+      #    retention-days: 7
+      #    path: ${{ package}}/*.nupkg
+      - name: Publish nupkg and snupkg to NuGet.org
+        run: |
+          foreach($file in (Get-ChildItem package -Recurse -Include *.nupkg)) {
+              dotnet nuget push $file --api-key "${{ secrets.NUGET_ORG_PUSH_API_KEY_HELSEID }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
+          }
+          foreach($file in (Get-ChildItem "package" -Recurse -Include *.snupkg)) {
+              dotnet nuget push $file --api-key "${{ secrets.NUGET_ORG_PUSH_API_KEY_HELSEID }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
+          }

--- a/Fhi.HelseId.Swagger.Tests/Fhi.HelseId.Swagger.Tests.csproj
+++ b/Fhi.HelseId.Swagger.Tests/Fhi.HelseId.Swagger.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Fhi.HelseId.Swagger\Fhi.HelseId.Swagger.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Fhi.HelseId.Swagger.Tests/GlobalUsings.cs
+++ b/Fhi.HelseId.Swagger.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using NUnit.Framework;

--- a/Fhi.HelseId.Swagger.Tests/WebApplicationBuilderExtensionsTests.cs
+++ b/Fhi.HelseId.Swagger.Tests/WebApplicationBuilderExtensionsTests.cs
@@ -1,0 +1,75 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Fhi.HelseId.Swagger.Tests;
+
+public class WebApplicationBuilderExtensionsTests
+{
+    [TestCase("Prod")]
+    [TestCase("Production")]
+    public void SwaggerTokenServicesAreNotRegisteredForProdEnvironments(string environmentName)
+    {
+        // Arrange
+        var builder = WebApplication.CreateBuilder();
+        builder.Environment.EnvironmentName = environmentName;
+        var swaggerHelseIdConfiguration = new SwaggerHelseIdConfiguration();
+
+        // Act
+        builder.AddHelseIdTestTokens(swaggerHelseIdConfiguration);
+
+        // Assert
+        Assert.That(builder.Services, Is.All.Not.Matches<ServiceDescriptor>(sd => sd.ServiceType == typeof(ITokenProxy)));
+        Assert.That(builder.Services, Is.All.Not.Matches<ServiceDescriptor>(sd => sd.ServiceType == typeof(SwaggerHelseIdConfiguration)));
+    }
+
+    [TestCase("Test")]
+    [TestCase("Stage")]
+    [TestCase("Development")]
+    public void SwaggerTokenServicesAreRegisteredForTestEnvironments(string environmentName)
+    {
+        // Arrange
+        var builder = WebApplication.CreateBuilder();
+        builder.Environment.EnvironmentName = environmentName;
+        var swaggerHelseIdConfiguration = new SwaggerHelseIdConfiguration();
+
+        // Act
+        builder.AddHelseIdTestTokens(swaggerHelseIdConfiguration);
+
+        // Assert
+        Assert.That(builder.Services, Has.Some.Matches<ServiceDescriptor>(sd => sd.ServiceType == typeof(ITokenProxy)));
+        Assert.That(builder.Services, Has.Some.Matches<ServiceDescriptor>(sd => sd.ServiceType == typeof(SwaggerHelseIdConfiguration)));
+    }
+
+    [Test]
+    public void SwaggerTokenServicesAreRegisteredForSpecifiedEnvironments()
+    {
+        // Arrange
+        var builder = WebApplication.CreateBuilder();
+        builder.Environment.EnvironmentName = "SwaggerRequiredEnvironment";
+        var swaggerHelseIdConfiguration = new SwaggerHelseIdConfiguration();
+
+        // Act
+        builder.AddHelseIdTestTokens(swaggerHelseIdConfiguration, ["SwaggerRequiredEnvironment"]);
+
+        // Assert
+        Assert.That(builder.Services, Has.Some.Matches<ServiceDescriptor>(sd => sd.ServiceType == typeof(ITokenProxy)));
+        Assert.That(builder.Services, Has.Some.Matches<ServiceDescriptor>(sd => sd.ServiceType == typeof(SwaggerHelseIdConfiguration)));
+    }
+
+
+    [Test]
+    public void SwaggerTokenServicesAreNotRegisteredForUnspecifiedEnvironments()
+    {
+        // Arrange
+        var builder = WebApplication.CreateBuilder();
+        builder.Environment.EnvironmentName = "RandomEnvironment";
+        var swaggerHelseIdConfiguration = new SwaggerHelseIdConfiguration();
+
+        // Act
+        builder.AddHelseIdTestTokens(swaggerHelseIdConfiguration, ["SwaggerRequiredEnvironment"]);
+
+        // Assert
+        Assert.That(builder.Services, Is.All.Not.Matches<ServiceDescriptor>(sd => sd.ServiceType == typeof(ITokenProxy)));
+        Assert.That(builder.Services, Is.All.Not.Matches<ServiceDescriptor>(sd => sd.ServiceType == typeof(SwaggerHelseIdConfiguration)));
+    }
+}

--- a/Fhi.HelseId.Swagger/Fhi.HelseId.Swagger.csproj
+++ b/Fhi.HelseId.Swagger/Fhi.HelseId.Swagger.csproj
@@ -5,20 +5,20 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <id>Fhi.HelseId.Swagger</id>
-    <Version>1.0.1</Version>
+    <Version>1.0.0</Version>
     <authors>Folkehelseinstituttet (FHI)</authors>
-    <Copyright>©2023-2024 Folkehelseinstituttet (FHI)</Copyright>
+    <Copyright>©2024 Folkehelseinstituttet (FHI)</Copyright>
     <projectUrl>https://github.com/folkehelseinstituttet/Fhi.HelseId</projectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <icon>https://github.com/folkehelseinstituttet/Fhi.HelseId/images/fhi.png</icon>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageDescription>Setup Swagger with HelseID Apis</PackageDescription>
-    <PackageCopyright>Copyright ©2023-2024 Folkehelseinstituttet</PackageCopyright>
+    <PackageCopyright>Copyright ©2024 Folkehelseinstituttet</PackageCopyright>
     <!-- Tags appear in the gallery and can be used for tag searches -->
     <Tags>helseid, oauth, Refit, Swagger</Tags>
     <RepositoryUrl>https://github.com/folkehelseinstituttet/Fhi.HelseId</RepositoryUrl>
     <dependencies>
-      <group targetFramework="net6.0">
+      <group targetFramework="net8.0">
       </group>
     </dependencies>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/Fhi.HelseId.Swagger/Fhi.HelseId.Swagger.csproj
+++ b/Fhi.HelseId.Swagger/Fhi.HelseId.Swagger.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <id>Fhi.HelseId.Swagger</id>
+    <Version>1.0.1</Version>
+    <authors>Folkehelseinstituttet (FHI)</authors>
+    <Copyright>©2023-2024 Folkehelseinstituttet (FHI)</Copyright>
+    <projectUrl>https://github.com/folkehelseinstituttet/Fhi.HelseId</projectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <icon>https://github.com/folkehelseinstituttet/Fhi.HelseId/images/fhi.png</icon>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageDescription>Setup Swagger with HelseID Apis</PackageDescription>
+    <PackageCopyright>Copyright ©2023-2024 Folkehelseinstituttet</PackageCopyright>
+    <!-- Tags appear in the gallery and can be used for tag searches -->
+    <Tags>helseid, oauth, Refit, Swagger</Tags>
+    <RepositoryUrl>https://github.com/folkehelseinstituttet/Fhi.HelseId</RepositoryUrl>
+    <dependencies>
+      <group targetFramework="net6.0">
+      </group>
+    </dependencies>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Fhi.HelseId" Version="5.*" />
+  </ItemGroup>
+
+</Project>

--- a/Fhi.HelseId.Swagger/README.md
+++ b/Fhi.HelseId.Swagger/README.md
@@ -15,7 +15,7 @@ You will need a separate client in HelseID selvbetjening for the Swagger client.
 ```json
   "SwaggerHelseIdConfiguration": {
     "TokenEndpoint": "https://localhost:7113/.swagger-dev/token",
-    "clientName": "FOLKEHELSEINSTITUTTET -  Fhi.Sysvak.Epj.Testklient.dev (Test)",
+    "clientName": "FOLKEHELSEINSTITUTTET -  Fhi.SomeServiceName",
     "authority": "https://helseid-sts.test.nhn.no",
     "clientId": "fcffea32-8f2d-4efc-a25a-b668a788d4f1",
     "grantTypes": [
@@ -24,7 +24,7 @@ You will need a separate client in HelseID selvbetjening for the Swagger client.
     "scopes": [
       "openid",
       "helseid://scopes/hpr/hpr_number",
-      "fhi:sysvak.epj.dev/api"
+      "fhi:someservicename/api"
     ],
     "redirectUris": [
       "https://localhost:44380/swagger/oauth2-redirect.html"
@@ -45,6 +45,10 @@ The `TokenEndpoint` will point towards the test token endpoint that Swagger will
 Add required services and configuration:
 
 ```csharp
+using Fhi.HelseId.Swagger;
+
+// ...
+
 if (builder.Environment.IsDevelopment())
 {
     var swaggerAuthConfig = builder.Configuration.GetSection(nameof(SwaggerHelseIdConfiguration)).Get<SwaggerHelseIdConfiguration>()!;

--- a/Fhi.HelseId.Swagger/README.md
+++ b/Fhi.HelseId.Swagger/README.md
@@ -8,7 +8,7 @@ The endpoint that is provided in this package is only intended to be used in dev
 
 The example bellow is intended for the usage of an API that requires a token using the authorization code flow.
 
-## appsettings.json
+## Setting up appsettings.json when using HelseID as an STS
 
 You will need a separate client in HelseID selvbetjening for the Swagger client. After creating the client, add the HelseID configuration to appsettings under a `SwaggerHelseIdConfiguration` property and add the `TokenEndpoint` property as follows:
 

--- a/Fhi.HelseId.Swagger/README.md
+++ b/Fhi.HelseId.Swagger/README.md
@@ -1,0 +1,109 @@
+﻿# Fhi.HelseId.Swagger
+
+This package provides infrastructure so that developers can easily use Swagger with HelseID and generate tokens within their browsers. This functionality is limited in Swagger out of the box due to the fact it does not yet support JWT Bearer client assertions when creating the token. This package adds a test token endpoint that will act as a proxy between Swagger and authority in order to create a token request towards the authority using a JWT Bearer client assertion.
+
+The endpoint that is provided in this package is only intended to be used in development context and not in a production environment.
+
+# Getting started
+
+The example bellow is intended for the usage of an API that requires a token using the authorization code flow.
+
+## appsettings.json
+
+You will need a separate client in HelseID selvbetjening for the Swagger client. After creating the client, add the HelseID configuration to appsettings under a `SwaggerHelseIdConfiguration` property and add the `TokenEndpoint` property as follows:
+
+```json
+  "SwaggerHelseIdConfiguration": {
+    "TokenEndpoint": "https://localhost:7113/.swagger-dev/token",
+    "clientName": "FOLKEHELSEINSTITUTTET -  Fhi.Sysvak.Epj.Testklient.dev (Test)",
+    "authority": "https://helseid-sts.test.nhn.no",
+    "clientId": "fcffea32-8f2d-4efc-a25a-b668a788d4f1",
+    "grantTypes": [
+      "authorization_code"
+    ],
+    "scopes": [
+      "openid",
+      "helseid://scopes/hpr/hpr_number",
+      "fhi:sysvak.epj.dev/api"
+    ],
+    "redirectUris": [
+      "https://localhost:44380/swagger/oauth2-redirect.html"
+    ],
+    "postLogoutRedirectUris": [],
+    "secretType": "private_key_jwt:RsaPrivateKeyJwtSecret",
+    "rsaPrivateKey": "\u003CRSAKeyValue\u003E\u003...",
+    "rsaKeySizeBits": 4096,
+    "privateJwk": "{\u0022d\u0022:\u0022Qo5q2Fo...}",
+    "pkceRequired": true
+  }
+```
+
+The `TokenEndpoint` will point towards the test token endpoint that Swagger will use to obtain an authorization token.
+
+## Program.cs
+
+Add required services and configuration:
+
+```csharp
+if (builder.Environment.IsDevelopment())
+{
+    var swaggerAuthConfig = builder.Configuration.GetSection(nameof(SwaggerHelseIdConfiguration)).Get<SwaggerHelseIdConfiguration>()!;
+    builder.AddHelseIdTestTokens(swaggerAuthConfig);
+}
+```
+
+Ensure that `AddSwaggerGen` is configured to use the auth token:
+
+```csharp
+builder.Services.AddSwaggerGen(c =>
+{
+    var securityScheme = new OpenApiSecurityScheme
+    {
+        In = ParameterLocation.Header,
+        Type = SecuritySchemeType.OAuth2,
+        Flows = new OpenApiOAuthFlows
+        {
+            AuthorizationCode = new OpenApiOAuthFlow()
+            {
+                AuthorizationUrl = new Uri($"{swaggerAuthConfig.Authority}/connect/authorize"),
+                TokenUrl = new Uri(swaggerAuthConfig.TokenEndpoint),
+                Scopes = swaggerAuthConfig.Scopes.ToDictionary(k => k, v => string.Empty)
+            }
+        },
+        Reference = new OpenApiReference
+        {
+            Id = JwtBearerDefaults.AuthenticationScheme,
+            Type = ReferenceType.SecurityScheme
+        }
+    };
+
+    c.AddSecurityDefinition(securityScheme.Reference.Id, securityScheme);
+
+    c.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        { securityScheme, Array.Empty<string>() }
+    });
+    /// ...
+});
+```
+
+and add the test token end point together with configuration of how Swagger UI will build the token requests:
+```csharp
+if (app.Environment.IsDevelopment())
+{
+    var swaggerAuthConfig = app.Services.GetRequiredService<SwaggerHelseIdConfiguration>();
+
+    app.UseSwagger();
+    app.UseSwaggerUI(options =>
+    {
+        options.OAuthAppName(swaggerAuthConfig.ClientName);
+        options.OAuthClientId(swaggerAuthConfig.ClientId);
+
+        options.OAuthScopeSeparator(" ");
+        options.OAuthUsePkce();
+        options.OAuthScopes(swaggerAuthConfig.Scopes);
+    });
+    app.UseHelseIdTestTokenEndpoint();
+}
+```
+

--- a/Fhi.HelseId.Swagger/README.md
+++ b/Fhi.HelseId.Swagger/README.md
@@ -10,7 +10,7 @@ The example bellow is intended for the usage of an API that requires a token usi
 
 ## Setting up appsettings.json when using HelseID as an STS
 
-You will need a separate client in HelseID selvbetjening for the Swagger client. After creating the client, add the HelseID configuration to appsettings under a `SwaggerHelseIdConfiguration` property and add the `TokenEndpoint` property as follows:
+You will need a separate client registration in HelseID selvbetjening for the Swagger client. After creating the client registration, add the HelseID configuration to appsettings under a `SwaggerHelseIdConfiguration` property and add the `TokenEndpoint` property as follows:
 
 ```json
   "SwaggerHelseIdConfiguration": {

--- a/Fhi.HelseId.Swagger/SwaggerHelseIdConfiguration.cs
+++ b/Fhi.HelseId.Swagger/SwaggerHelseIdConfiguration.cs
@@ -1,0 +1,23 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Fhi.HelseId.Swagger;
+
+public class SwaggerHelseIdConfiguration
+{
+    public string TokenEndpoint { get; set; } = "";
+
+    [JsonPropertyName("clientName")]
+    public string ClientName { get; set; } = "";
+
+    [JsonPropertyName("authority")]
+    public string Authority { get; set; } = "";
+
+    [JsonPropertyName("clientId")]
+    public string ClientId { get; set; } = "";
+
+    [JsonPropertyName("scopes")]
+    public string[] Scopes { get; set; } = [];
+
+    [JsonPropertyName("privateJwk")]
+    public string PrivateJwk { get; set; } = "";
+}

--- a/Fhi.HelseId.Swagger/TokenProxy.cs
+++ b/Fhi.HelseId.Swagger/TokenProxy.cs
@@ -1,0 +1,48 @@
+﻿using Fhi.HelseId.Common.Identity;
+using Fhi.HelseId.Web;
+using Microsoft.IdentityModel.Tokens;
+using System.Web;
+
+namespace Fhi.HelseId.Swagger;
+
+public interface ITokenProxy
+{
+    Task<string?> RequestToken(Dictionary<string, string?> requestParameters);
+}
+
+public class TokenProxy : ITokenProxy
+{
+    private readonly SwaggerHelseIdConfiguration _swaggerHelseIdConfiguration;
+    private readonly HttpClient _tokenClient;
+
+    public TokenProxy(SwaggerHelseIdConfiguration swaggerHelseIdConfiguration)
+    {
+        _swaggerHelseIdConfiguration = swaggerHelseIdConfiguration;
+        _tokenClient = new HttpClient();
+    }
+
+    public async Task<string?> RequestToken(Dictionary<string, string?> requestParameters)
+    {
+        var config = new HelseIdWebKonfigurasjon
+        {
+            ClientId = _swaggerHelseIdConfiguration.ClientId,
+            Authority = _swaggerHelseIdConfiguration.Authority,
+        };
+
+        var jwk = HttpUtility.UrlDecode(_swaggerHelseIdConfiguration.PrivateJwk);
+        var jwkSecurityKey = new JsonWebKey(jwk);
+
+        var clientAssertion = ClientAssertion.Generate(config, jwkSecurityKey);
+
+        requestParameters["client_id"] = config.ClientId;
+        requestParameters["client_assertion_type"] = IdentityModel.OidcConstants.ClientAssertionTypes.JwtBearer;
+        requestParameters["client_assertion"] = clientAssertion;
+
+        var tokenUrl = $"{_swaggerHelseIdConfiguration.Authority}/connect/token";
+        var result = await _tokenClient.PostAsync(tokenUrl, new FormUrlEncodedContent(requestParameters));
+
+        var jsonResult = await result.Content.ReadAsStringAsync();
+
+        return jsonResult;
+    }
+}

--- a/Fhi.HelseId.Swagger/WebApplicationBuilderExtensions.cs
+++ b/Fhi.HelseId.Swagger/WebApplicationBuilderExtensions.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Fhi.HelseId.Swagger;
+
+public static class WebApplicationBuilderExtensions
+{
+    public static WebApplicationBuilder AddHelseIdTestTokens(this WebApplicationBuilder builder, SwaggerHelseIdConfiguration swaggerAuthConfig)
+    {
+        if (builder.Environment.IsDevelopment())
+        {
+            builder.Services.AddSingleton(swaggerAuthConfig);
+            builder.Services.AddSingleton<ITokenProxy, TokenProxy>();
+        }
+
+        return builder;
+    }
+}

--- a/Fhi.HelseId.Swagger/WebApplicationBuilderExtensions.cs
+++ b/Fhi.HelseId.Swagger/WebApplicationBuilderExtensions.cs
@@ -1,14 +1,17 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 
 namespace Fhi.HelseId.Swagger;
 
 public static class WebApplicationBuilderExtensions
 {
-    public static WebApplicationBuilder AddHelseIdTestTokens(this WebApplicationBuilder builder, SwaggerHelseIdConfiguration swaggerAuthConfig)
+    public static WebApplicationBuilder AddHelseIdTestTokens(this WebApplicationBuilder builder, SwaggerHelseIdConfiguration swaggerAuthConfig, string[]? enabledEnvironments = null)
     {
-        if (builder.Environment.IsDevelopment())
+        var currentEnvironmentName = builder.Environment.EnvironmentName;
+
+        var isProduction = currentEnvironmentName.StartsWith("Prod", StringComparison.OrdinalIgnoreCase);
+
+        if (enabledEnvironments?.Contains(currentEnvironmentName) == true && !isProduction)
         {
             builder.Services.AddSingleton(swaggerAuthConfig);
             builder.Services.AddSingleton<ITokenProxy, TokenProxy>();

--- a/Fhi.HelseId.Swagger/WebApplicationBuilderExtensions.cs
+++ b/Fhi.HelseId.Swagger/WebApplicationBuilderExtensions.cs
@@ -5,13 +5,20 @@ namespace Fhi.HelseId.Swagger;
 
 public static class WebApplicationBuilderExtensions
 {
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <param name="swaggerAuthConfig"></param>
+    /// <param name="enabledEnvironments">Optional list of environments which the Swagger services will be registered for. If not specified, it will be registered for every environment except for production.</param>
+    /// <returns></returns>
     public static WebApplicationBuilder AddHelseIdTestTokens(this WebApplicationBuilder builder, SwaggerHelseIdConfiguration swaggerAuthConfig, string[]? enabledEnvironments = null)
     {
         var currentEnvironmentName = builder.Environment.EnvironmentName;
 
         var isProduction = currentEnvironmentName.StartsWith("Prod", StringComparison.OrdinalIgnoreCase);
 
-        if (enabledEnvironments?.Contains(currentEnvironmentName) == true && !isProduction)
+        if (enabledEnvironments?.Contains(currentEnvironmentName) ?? true && !isProduction)
         {
             builder.Services.AddSingleton(swaggerAuthConfig);
             builder.Services.AddSingleton<ITokenProxy, TokenProxy>();

--- a/Fhi.HelseId.Swagger/WebApplicationExtensions.cs
+++ b/Fhi.HelseId.Swagger/WebApplicationExtensions.cs
@@ -13,7 +13,7 @@ public static class WebApplicationExtensions
 
         var isProduction = currentEnvironmentName.StartsWith("Prod", StringComparison.OrdinalIgnoreCase);
 
-        if (enabledEnvironments?.Contains(currentEnvironmentName) == true && !isProduction)
+        if (enabledEnvironments?.Contains(currentEnvironmentName) ?? true && !isProduction)
         {
             return app.MapPost(".swagger-dev/token", async Task<IResult> ([FromForm] IFormCollection form, ITokenProxy tokenProxy) =>
             {

--- a/Fhi.HelseId.Swagger/WebApplicationExtensions.cs
+++ b/Fhi.HelseId.Swagger/WebApplicationExtensions.cs
@@ -1,16 +1,19 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Hosting;
 using System.Net.Mime;
 
 namespace Fhi.HelseId.Swagger;
 
 public static class WebApplicationExtensions
 {
-    public static RouteHandlerBuilder UseHelseIdTestTokenEndpoint(this WebApplication app)
+    public static RouteHandlerBuilder UseHelseIdTestTokenEndpoint(this WebApplication app, string[]? enabledEnvironments = null)
     {
-        if (app.Environment.IsDevelopment())
+        var currentEnvironmentName = app.Environment.EnvironmentName;
+
+        var isProduction = currentEnvironmentName.StartsWith("Prod", StringComparison.OrdinalIgnoreCase);
+
+        if (enabledEnvironments?.Contains(currentEnvironmentName) == true && !isProduction)
         {
             return app.MapPost(".swagger-dev/token", async Task<IResult> ([FromForm] IFormCollection form, ITokenProxy tokenProxy) =>
             {

--- a/Fhi.HelseId.Swagger/WebApplicationExtensions.cs
+++ b/Fhi.HelseId.Swagger/WebApplicationExtensions.cs
@@ -6,7 +6,7 @@ using System.Net.Mime;
 
 namespace Fhi.HelseId.Swagger;
 
-internal static class WebApplicationExtensions
+public static class WebApplicationExtensions
 {
     public static RouteHandlerBuilder UseHelseIdTestTokenEndpoint(this WebApplication app)
     {

--- a/Fhi.HelseId.Swagger/WebApplicationExtensions.cs
+++ b/Fhi.HelseId.Swagger/WebApplicationExtensions.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Hosting;
+using System.Net.Mime;
+
+namespace Fhi.HelseId.Swagger;
+
+internal static class WebApplicationExtensions
+{
+    public static RouteHandlerBuilder UseHelseIdTestTokenEndpoint(this WebApplication app)
+    {
+        if (app.Environment.IsDevelopment())
+        {
+            return app.MapPost(".swagger-dev/token", async Task<IResult> ([FromForm] IFormCollection form, ITokenProxy tokenProxy) =>
+            {
+                var requestParameters = form.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.First());
+                var jsonResult = await tokenProxy.RequestToken(requestParameters);
+
+                return Results.Text(jsonResult, MediaTypeNames.Application.Json);
+            })
+            .DisableAntiforgery()
+            .ExcludeFromDescription();
+        }
+
+        return new RouteHandlerBuilder([]);
+    }
+}

--- a/Fhi.HelseId.sln
+++ b/Fhi.HelseId.sln
@@ -42,10 +42,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\Fhi.AuthController.Nuget.yml = .github\workflows\Fhi.AuthController.Nuget.yml
 		.github\workflows\Fhi.HelseId.AltInn.Nuget = .github\workflows\Fhi.HelseId.AltInn.Nuget
 		.github\workflows\Fhi.HelseId.Blazor.Nuget.yml = .github\workflows\Fhi.HelseId.Blazor.Nuget.yml
-		.github\workflows\Fhi.HelseId.Swagger.Nuget.yml = .github\workflows\Fhi.HelseId.Swagger.Nuget.yml
 		.github\workflows\Fhi.HelseId.CI.yml = .github\workflows\Fhi.HelseId.CI.yml
 		.github\workflows\Fhi.HelseId.Nuget.yml = .github\workflows\Fhi.HelseId.Nuget.yml
 		.github\workflows\Fhi.HelseId.Refit.Nuget.yml = .github\workflows\Fhi.HelseId.Refit.Nuget.yml
+		.github\workflows\Fhi.HelseId.Swagger.Nuget.yml = .github\workflows\Fhi.HelseId.Swagger.Nuget.yml
 		.github\workflows\Fhi.HelseId.TestSupport.Nuget.yml = .github\workflows\Fhi.HelseId.TestSupport.Nuget.yml
 		.github\workflows\SonarBuild.yml = .github\workflows\SonarBuild.yml
 	EndProjectSection
@@ -59,6 +59,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fhi.HelseId.Blazor", "Fhi.HelseId.Blazor\Fhi.HelseId.Blazor.csproj", "{FFC0B4DA-7D53-467F-BBAC-59CBCBDA1078}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fhi.HelseId.Swagger", "Fhi.HelseId.Swagger\Fhi.HelseId.Swagger.csproj", "{D6B3A10C-B329-4745-9883-B2D3A6D3D1D2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fhi.HelseId.Swagger.Tests", "Fhi.HelseId.Swagger.Tests\Fhi.HelseId.Swagger.Tests.csproj", "{5C7453F7-9625-41C0-AA34-B082A87C990A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -102,6 +104,10 @@ Global
 		{D6B3A10C-B329-4745-9883-B2D3A6D3D1D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D6B3A10C-B329-4745-9883-B2D3A6D3D1D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D6B3A10C-B329-4745-9883-B2D3A6D3D1D2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5C7453F7-9625-41C0-AA34-B082A87C990A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5C7453F7-9625-41C0-AA34-B082A87C990A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5C7453F7-9625-41C0-AA34-B082A87C990A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5C7453F7-9625-41C0-AA34-B082A87C990A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Fhi.HelseId.sln
+++ b/Fhi.HelseId.sln
@@ -42,6 +42,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\Fhi.AuthController.Nuget.yml = .github\workflows\Fhi.AuthController.Nuget.yml
 		.github\workflows\Fhi.HelseId.AltInn.Nuget = .github\workflows\Fhi.HelseId.AltInn.Nuget
 		.github\workflows\Fhi.HelseId.Blazor.Nuget.yml = .github\workflows\Fhi.HelseId.Blazor.Nuget.yml
+		.github\workflows\Fhi.HelseId.Swagger.Nuget.yml = .github\workflows\Fhi.HelseId.Swagger.Nuget.yml
 		.github\workflows\Fhi.HelseId.CI.yml = .github\workflows\Fhi.HelseId.CI.yml
 		.github\workflows\Fhi.HelseId.Nuget.yml = .github\workflows\Fhi.HelseId.Nuget.yml
 		.github\workflows\Fhi.HelseId.Refit.Nuget.yml = .github\workflows\Fhi.HelseId.Refit.Nuget.yml

--- a/Fhi.HelseId.sln
+++ b/Fhi.HelseId.sln
@@ -57,6 +57,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fhi.HelseId.Refit", "Fhi.He
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fhi.HelseId.Blazor", "Fhi.HelseId.Blazor\Fhi.HelseId.Blazor.csproj", "{FFC0B4DA-7D53-467F-BBAC-59CBCBDA1078}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fhi.HelseId.Swagger", "Fhi.HelseId.Swagger\Fhi.HelseId.Swagger.csproj", "{D6B3A10C-B329-4745-9883-B2D3A6D3D1D2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -95,6 +97,10 @@ Global
 		{FFC0B4DA-7D53-467F-BBAC-59CBCBDA1078}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FFC0B4DA-7D53-467F-BBAC-59CBCBDA1078}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FFC0B4DA-7D53-467F-BBAC-59CBCBDA1078}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D6B3A10C-B329-4745-9883-B2D3A6D3D1D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D6B3A10C-B329-4745-9883-B2D3A6D3D1D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D6B3A10C-B329-4745-9883-B2D3A6D3D1D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D6B3A10C-B329-4745-9883-B2D3A6D3D1D2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This PR adds a new package `Fhi.HelseId.Swagger` that makes it possible to create HelseID within the SwaggerUI and makes testing with a valid token effortless using the authorization token auth flow.