### PR TITLE
Skip Auth header if Anonymous-Options is given to request message

### DIFF
--- a/Fhi.HelseId.Tests/AuthHeaderHandlerTests.cs
+++ b/Fhi.HelseId.Tests/AuthHeaderHandlerTests.cs
@@ -1,0 +1,101 @@
+﻿using Fhi.HelseId.Common;
+using Fhi.HelseId.Web;
+using Fhi.HelseId.Web.Infrastructure.AutomaticTokenManagement;
+using Fhi.HelseId.Web.Services;
+using IdentityModel.AspNetCore.AccessTokenManagement;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fhi.HelseId.Tests;
+public class AuthHeaderHandlerTests
+{
+    [Test]
+    public async Task HandlerAddsAuthToken()
+    {
+        var authToken = Guid.NewGuid().ToString();
+
+        var httpContextAccessor = Substitute.For<IHttpContextAccessor>();
+        var context = Substitute.For<HttpContext>();
+        var services = new ServiceCollection();
+        var tokenService = Substitute.For<IUserAccessTokenManagementService>();
+        tokenService.GetUserAccessTokenAsync(
+            Arg.Any<ClaimsPrincipal>(), 
+            Arg.Any<UserAccessTokenParameters?>(),
+            Arg.Any<CancellationToken>()).Returns(Task.FromResult((string?)authToken));
+        services.AddSingleton(tokenService);
+        context.RequestServices.Returns(services.BuildServiceProvider());
+        httpContextAccessor.HttpContext.Returns(context);
+
+        var handler = new AuthHeaderHandler(
+            httpContextAccessor,
+            NullLogger<AuthHeaderHandler>.Instance,
+            Substitute.For<IRefreshTokenStore>(),
+            Substitute.For<ICurrentUser>(),
+            Options.Create(new HelseIdWebKonfigurasjon()));
+
+        handler.InnerHandler = new DummyInnerHandler();
+
+        var client = new HttpClient(handler);
+        var request = new HttpRequestMessage(HttpMethod.Get, "http://localhost/");
+        var response = await client.SendAsync(request);
+
+        var token = await response.Content.ReadAsStringAsync();
+
+        // the dummy client returns the authorization header
+        Assert.That(token, Is.EqualTo("Bearer " + authToken));
+    }
+
+    [Test]
+    public async Task HandlerDoesNotGetTokenWhenAnonymous()
+    {
+        var httpContextAccessor = Substitute.For<IHttpContextAccessor>();
+        var context = Substitute.For<HttpContext>();
+        var services = new ServiceCollection();
+        var tokenService = Substitute.For<IUserAccessTokenManagementService>();
+        services.AddSingleton(tokenService);
+        context.RequestServices.Returns(services.BuildServiceProvider());
+        httpContextAccessor.HttpContext.Returns(context);
+
+        var handler = new AuthHeaderHandler(
+            httpContextAccessor,
+            NullLogger<AuthHeaderHandler>.Instance,
+            Substitute.For<IRefreshTokenStore>(),
+            Substitute.For<ICurrentUser>(),
+            Options.Create(new HelseIdWebKonfigurasjon()));
+
+        handler.InnerHandler = new DummyInnerHandler();
+
+        var client = new HttpClient(handler);
+        var request = new HttpRequestMessage(HttpMethod.Get, "http://localhost/");
+        request.Options.TryAdd("Anonymous", "Anonymous");
+        var response = await client.SendAsync(request);
+
+        var token = await response.Content.ReadAsStringAsync();
+
+        Assert.That(token, Is.EqualTo(""));
+    }
+}
+
+public class DummyInnerHandler : HttpClientHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        // Get any auth header, and use its value as the content of the request
+        var auth = request.Headers.FirstOrDefault(x => x.Key == "Authorization").Value?.FirstOrDefault() ?? "";
+        var response = new HttpResponseMessage() { Content = new StringContent(auth) };
+        return Task.FromResult(response);
+    }
+}
+
+

--- a/Fhi.HelseId/Common/AuthHeaderHandler.cs
+++ b/Fhi.HelseId/Common/AuthHeaderHandler.cs
@@ -93,7 +93,7 @@ public class AuthHeaderHandlerForApi : DelegatingHandler
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        if (request.Options.All(x => x.Key != AnonymousOptionKey))
+        if (request.Options.Any(x => x.Key == AnonymousOptionKey))
         {
             return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
         }

--- a/Fhi.HelseId/Common/AuthHeaderHandler.cs
+++ b/Fhi.HelseId/Common/AuthHeaderHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
@@ -21,6 +22,8 @@ namespace Fhi.HelseId.Common;
 /// </summary>
 public class AuthHeaderHandler : DelegatingHandler
 {
+    public const string AnonymousOptionKey = "Anonymous";
+
     private readonly IHttpContextAccessor contextAccessor;
     private readonly ILogger<AuthHeaderHandler> logger;
     private readonly IRefreshTokenStore refreshTokenStore;
@@ -42,11 +45,17 @@ public class AuthHeaderHandler : DelegatingHandler
     }
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
+        if (request.Options.All(x => x.Key != AnonymousOptionKey))
+        {
+            logger.LogTrace("{class}.{method} - Skipping Access token because of anonymous HttpRequestMessage options", nameof(AuthHeaderHandler), nameof(SendAsync));
+            return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+
         var ctx = contextAccessor.HttpContext ?? throw new NoContextException();
         logger.LogTrace("{class}.{method} - Starting", nameof(AuthHeaderHandler), nameof(SendAsync));
         var token = await ctx.GetUserAccessTokenAsync(cancellationToken: cancellationToken);
 
-        if (config.UseRefreshTokenStore && refreshTokenStore.GetLatestToken(user)!=null && !string.IsNullOrEmpty(refreshTokenStore.GetLatestToken(user)?.AccessToken) && refreshTokenStore.GetLatestToken(user)?.AccessToken != token)
+        if (config.UseRefreshTokenStore && refreshTokenStore.GetLatestToken(user) != null && !string.IsNullOrEmpty(refreshTokenStore.GetLatestToken(user)?.AccessToken) && refreshTokenStore.GetLatestToken(user)?.AccessToken != token)
             token = refreshTokenStore.GetLatestToken(user)?.AccessToken;
         if (token == null)
         {
@@ -54,13 +63,13 @@ public class AuthHeaderHandler : DelegatingHandler
         }
         else
         {
-            logger.LogTrace("{class}.{method} - Found access token in context (hash:{hash})", nameof(AuthHeaderHandler), nameof(SendAsync),token.GetHashCode());
+            logger.LogTrace("{class}.{method} - Found access token in context (hash:{hash})", nameof(AuthHeaderHandler), nameof(SendAsync), token.GetHashCode());
         }
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
         var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)
         {
-            logger.LogError("{class}.{method} Request to {url} failed with status code {statusCode}", nameof(AuthHeaderHandler), nameof(SendAsync),request.RequestUri, response.StatusCode);
+            logger.LogError("{class}.{method} Request to {url} failed with status code {statusCode}", nameof(AuthHeaderHandler), nameof(SendAsync), request.RequestUri, response.StatusCode);
         }
 
         return response;
@@ -82,12 +91,12 @@ public class AuthHeaderHandlerForApi : DelegatingHandler
     {
         var ctx = contextAccessor.HttpContext ?? throw new NoContextException();
         var token = await ctx.AccessToken();
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer",  token);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
         return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
     }
 }
 
-public class NoContextException: Exception
+public class NoContextException : Exception
 {
     //
     // For guidelines regarding the creation of new exception types, see

--- a/Fhi.HelseId/Fhi.HelseId.csproj
+++ b/Fhi.HelseId/Fhi.HelseId.csproj
@@ -11,7 +11,6 @@
     <Copyright>(c) 2020-2024 Folkehelseinstituttet (FHI), Nasjonalt Helsenett (NHN)</Copyright>
     <projectUrl>https://github.com/folkehelseinstituttet/Fhi.HelseId</projectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <icon>https://github.com/folkehelseinstituttet/Fhi.HelseId/images/fhi.png</icon>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageReleaseNotes>Fix </PackageReleaseNotes>
     <PackageDescription>Authentication and authorization component for access to NHN HelseId</PackageDescription>
@@ -27,6 +26,7 @@
     </dependencies>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageIcon>fhi.png</PackageIcon>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Fhi.HelseId/Fhi.HelseId.csproj
+++ b/Fhi.HelseId/Fhi.HelseId.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <Configurations>Debug;Release</Configurations>
     <id>Fhi.HelseId</id>
-    <Version>5.6.0</Version>
+    <Version>5.7.0</Version>
     <authors>Folkehelseinstituttet (FHI), Nasjonalt Helsenett (NHN)</authors>
     <Copyright>(c) 2020-2024 Folkehelseinstituttet (FHI), Nasjonalt Helsenett (NHN)</Copyright>
     <projectUrl>https://github.com/folkehelseinstituttet/Fhi.HelseId</projectUrl>
@@ -36,6 +36,7 @@
 
   <ItemGroup>
     <None Include="..\README.md" Pack="true" PackagePath="\" />
+    <None Include="..\images\fhi.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
 


### PR DESCRIPTION
In some cases we might wish to call an API before we are authenticated (health endpoints, kodeverk, etc..).

To make the HttpAuthHandler not add authentication headers to a single request you can add an Option
to the request with the key name "Anonymous"