### PR TITLE
Fix for wrong order of adding the logging delegation handler

### DIFF
--- a/Fhi.HelseId.Blazor.Tests/LoggingDelegationHandlerTests.cs
+++ b/Fhi.HelseId.Blazor.Tests/LoggingDelegationHandlerTests.cs
@@ -1,8 +1,4 @@
-using Microsoft.Extensions.Logging;
-using Microsoft.Net.Http.Headers;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -28,25 +24,5 @@ public class LoggingDelegationHandlerTests
         Assert.That(logger.Entries.Single(),
             Contains.Substring("with response 200 OK with CorrelationId TESTCORR"));
 
-    }
-}
-
-public class TestLogger<T> : ILogger<T>
-{
-    public List<string> Entries = [];
-
-    public IDisposable? BeginScope<TState>(TState state) where TState : notnull
-    {
-        return null;
-    }
-
-    public bool IsEnabled(LogLevel logLevel)
-    {
-        return true;
-    }
-
-    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
-    {
-        Entries.Add(logLevel.ToString() + " " + formatter(state, exception));
     }
 }

--- a/Fhi.HelseId.Blazor.Tests/TestLogger.cs
+++ b/Fhi.HelseId.Blazor.Tests/TestLogger.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+
+namespace Fhi.HelseId.Blazor.Tests;
+
+public class TestLogger<T> : ILogger<T>
+{
+    public List<string> Entries = [];
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+    {
+        return null;
+    }
+
+    public bool IsEnabled(LogLevel logLevel)
+    {
+        return true;
+    }
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        Entries.Add(logLevel.ToString() + " " + formatter(state, exception));
+    }
+}

--- a/Fhi.HelseId.Blazor/Fhi.HelseId.Blazor.csproj
+++ b/Fhi.HelseId.Blazor/Fhi.HelseId.Blazor.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <id>Fhi.HelseId.Blazor</id>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <authors>Folkehelseinstituttet (FHI)</authors>
     <Copyright>©2023-2024 Folkehelseinstituttet (FHI)</Copyright>
     <projectUrl>https://github.com/folkehelseinstituttet/Fhi.HelseId</projectUrl>

--- a/Fhi.HelseId.Blazor/HelseidRefitBuilderForBlazor.cs
+++ b/Fhi.HelseId.Blazor/HelseidRefitBuilderForBlazor.cs
@@ -49,10 +49,6 @@ namespace Fhi.HelseId.Blazor
             {
                 AddHandler<FhiHeaderDelegationHandler>();
             }
-            if (this.builderOptions.UseAnonymizationLogger)
-            {
-                AddHandler<LoggingDelegationHandler>();
-            }
             if (this.builderOptions.UseCorrelationId)
             {
                 AddHandler<CorrelationIdHandler>();
@@ -61,6 +57,10 @@ namespace Fhi.HelseId.Blazor
                 {
                     o.Headers.Add(CorrelationIdHandler.CorrelationIdHeaderName, context => string.IsNullOrEmpty(context.HeaderValue) ? Guid.NewGuid().ToString() : context.HeaderValue);
                 });
+            }
+            if (this.builderOptions.UseAnonymizationLogger)
+            {
+                AddHandler<LoggingDelegationHandler>();
             }
         }
 

--- a/Fhi.HelseId.Refit/Fhi.HelseId.Refit.csproj
+++ b/Fhi.HelseId.Refit/Fhi.HelseId.Refit.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <id>Fhi.HelseId.Refit</id>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <id>Fhi.HelseId.Refit</id>
     <authors>Folkehelseinstituttet (FHI)</authors>
     <Copyright>©2023-2024 Folkehelseinstituttet (FHI)</Copyright>

--- a/Fhi.HelseId.Refit/HelseidRefitBuilder.cs
+++ b/Fhi.HelseId.Refit/HelseidRefitBuilder.cs
@@ -45,10 +45,6 @@ namespace Fhi.HelseId.Refit
             {
                 AddHandler<FhiHeaderDelegationHandler>();
             }
-            if (this.builderOptions.UseAnonymizationLogger)
-            {
-                AddHandler<LoggingDelegationHandler>();
-            }
             if (this.builderOptions.UseCorrelationId)
             {
                 AddHandler<CorrelationIdHandler>();
@@ -58,6 +54,10 @@ namespace Fhi.HelseId.Refit
                 {
                     o.Headers.Add(CorrelationIdHandler.CorrelationIdHeaderName, context => string.IsNullOrEmpty(context.HeaderValue) ? Guid.NewGuid().ToString() : context.HeaderValue);
                 });
+            }
+            if (this.builderOptions.UseAnonymizationLogger)
+            {
+                AddHandler<LoggingDelegationHandler>();
             }
         }
 


### PR DESCRIPTION
Logging handler was added before correlatio handler, so logs always outputs null correlation id