### PR TITLE
Refit: Remove unneeded HeaderPropagation

### DIFF
--- a/Fhi.HelseId.Blazor/Fhi.HelseId.Blazor.csproj
+++ b/Fhi.HelseId.Blazor/Fhi.HelseId.Blazor.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <id>Fhi.HelseId.Blazor</id>
-    <Version>1.1.2</Version>
+    <Version>1.1.3-alpha.1</Version>
     <authors>Folkehelseinstituttet (FHI)</authors>
     <Copyright>©2023-2024 Folkehelseinstituttet (FHI)</Copyright>
     <projectUrl>https://github.com/folkehelseinstituttet/Fhi.HelseId</projectUrl>

--- a/Fhi.HelseId.Blazor/HelseIdState.cs
+++ b/Fhi.HelseId.Blazor/HelseIdState.cs
@@ -27,18 +27,26 @@ namespace Fhi.HelseId.Blazor
 
         private static string GetCorrelationId(HttpContext httpContext)
         {
-            var header = string.Empty;
+            var correlationId = Guid.NewGuid().ToString();
 
             if (httpContext.Request.Headers.TryGetValue(CorrelationIdHandler.CorrelationIdHeaderName, out var values))
             {
-                header = values.FirstOrDefault();
+                // if we find a correlation id on the request we update our default correlation Id
+                correlationId = values.First() ?? correlationId;
             }
-            else if (httpContext.Response.Headers.TryGetValue(CorrelationIdHandler.CorrelationIdHeaderName, out values))
+            else
             {
-                header = values.FirstOrDefault();
+                // if we did not find a correlation Id, set it to the default one so other code that reads correlation Id can see it
+                httpContext.Request.Headers.TryAdd(CorrelationIdHandler.CorrelationIdHeaderName, correlationId);
+            }
+            
+            if (!httpContext.Response.Headers.TryGetValue(CorrelationIdHandler.CorrelationIdHeaderName, out _))
+            {
+                // if we did not find a correlation Id, set it to the default one so other code that reads correlation Id can see it
+                httpContext.Response.Headers.TryAdd(CorrelationIdHandler.CorrelationIdHeaderName, correlationId);
             }
 
-            return string.IsNullOrEmpty(header) ? Guid.NewGuid().ToString() : header;
+            return correlationId;
         }
     }
 }

--- a/Fhi.HelseId.Blazor/HelseidRefitBuilderForBlazor.cs
+++ b/Fhi.HelseId.Blazor/HelseidRefitBuilderForBlazor.cs
@@ -52,11 +52,6 @@ namespace Fhi.HelseId.Blazor
             if (this.builderOptions.UseCorrelationId)
             {
                 AddHandler<CorrelationIdHandler>();
-
-                services.AddHeaderPropagation(o =>
-                {
-                    o.Headers.Add(CorrelationIdHandler.CorrelationIdHeaderName, context => string.IsNullOrEmpty(context.HeaderValue) ? Guid.NewGuid().ToString() : context.HeaderValue);
-                });
             }
             if (this.builderOptions.UseAnonymizationLogger)
             {

--- a/Fhi.HelseId.Blazor/WebApplicationExtensions.cs
+++ b/Fhi.HelseId.Blazor/WebApplicationExtensions.cs
@@ -65,7 +65,6 @@ namespace Fhi.HelseId.Blazor
             if (options.UseCorrelationId)
             {
                 app.UseMiddleware<CorrelationIdMiddleware>();
-                app.UseHeaderPropagation();
             }
 
             if (options.UseLogoutUrl)

--- a/Fhi.HelseId.Refit/Extensions.cs
+++ b/Fhi.HelseId.Refit/Extensions.cs
@@ -38,7 +38,6 @@ public static class Extensions
         if (options.UseCorrelationId)
         {
             app.UseMiddleware<CorrelationIdMiddleware>();
-            app.UseHeaderPropagation();
         }
 
         return app;

--- a/Fhi.HelseId.Refit/Fhi.HelseId.Refit.csproj
+++ b/Fhi.HelseId.Refit/Fhi.HelseId.Refit.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <id>Fhi.HelseId.Refit</id>
-    <Version>1.1.1</Version>
+    <Version>1.1.2-alpha.1</Version>
     <id>Fhi.HelseId.Refit</id>
     <authors>Folkehelseinstituttet (FHI)</authors>
     <Copyright>©2023-2024 Folkehelseinstituttet (FHI)</Copyright>

--- a/Fhi.HelseId.Refit/HelseidRefitBuilder.cs
+++ b/Fhi.HelseId.Refit/HelseidRefitBuilder.cs
@@ -48,12 +48,7 @@ namespace Fhi.HelseId.Refit
             if (this.builderOptions.UseCorrelationId)
             {
                 AddHandler<CorrelationIdHandler>();
-
                 services.AddHttpContextAccessor();
-                services.AddHeaderPropagation(o =>
-                {
-                    o.Headers.Add(CorrelationIdHandler.CorrelationIdHeaderName, context => string.IsNullOrEmpty(context.HeaderValue) ? Guid.NewGuid().ToString() : context.HeaderValue);
-                });
             }
             if (this.builderOptions.UseAnonymizationLogger)
             {
@@ -96,11 +91,6 @@ namespace Fhi.HelseId.Refit
             if (!builderOptions.PreserveDefaultLogger)
             {
                 clientBuilder.RemoveAllLoggers();
-            }
-
-            if (builderOptions.UseCorrelationId)
-            {
-                clientBuilder.AddHeaderPropagation();
             }
 
             foreach (var type in delegationHandlers)


### PR DESCRIPTION
As the CorrelationIdHandler handles propagating the correlation id header from the HttpContext to the Request, we do not need to add headerPropagation