### PR TITLE
Adjust scope logging, do not validate security level claims if user is not authenticated

### DIFF
--- a/Fhi.HelseId/Api/Handlers/ApiMultiScopeHandler.cs
+++ b/Fhi.HelseId/Api/Handlers/ApiMultiScopeHandler.cs
@@ -30,7 +30,7 @@ namespace Fhi.HelseId.Api.Handlers
             var scopeClaims = context.User.FindAll("scope").Where(s => s.Value.StartsWith(_configAuth.ApiName)).ToList();
             foreach (var claim in scopeClaims)
             {
-                logger.LogInformation($"Fhi.HelseId.Api.Handlers.{nameof(ApiMultiScopeHandler)}: Scope claim: {claim.Value}");
+                logger.LogTrace($"Fhi.HelseId.Api.Handlers.{nameof(ApiMultiScopeHandler)}: Scope claim: {claim.Value}");
             }
             if (!scopeClaims.Any())
             {
@@ -46,7 +46,7 @@ namespace Fhi.HelseId.Api.Handlers
             }
             foreach (var allowedScope in allowedScopes)
             {
-                logger.LogInformation("Fhi.HelseId.Api.Handlers.{class}: Allowed scope: {allowedScope}", nameof(ApiMultiScopeHandler), allowedScope);
+                logger.LogTrace("Fhi.HelseId.Api.Handlers.{class}: Allowed scope: {allowedScope}", nameof(ApiMultiScopeHandler), allowedScope);
             }
             var matches = scopes.Intersect(allowedScopes);
             if (matches.Any())

--- a/Fhi.HelseId/Fhi.HelseId.csproj
+++ b/Fhi.HelseId/Fhi.HelseId.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <Configurations>Debug;Release</Configurations>
     <id>Fhi.HelseId</id>
-    <Version>5.7.1</Version>
+    <Version>5.8.0</Version>
     <authors>Folkehelseinstituttet (FHI), Nasjonalt Helsenett (NHN)</authors>
     <Copyright>(c) 2020-2024 Folkehelseinstituttet (FHI), Nasjonalt Helsenett (NHN)</Copyright>
     <projectUrl>https://github.com/folkehelseinstituttet/Fhi.HelseId</projectUrl>

--- a/Fhi.HelseId/Web/Handlers/SecurityLevelClaimHandler.cs
+++ b/Fhi.HelseId/Web/Handlers/SecurityLevelClaimHandler.cs
@@ -23,6 +23,13 @@ namespace Fhi.HelseId.Web.Handlers
             AuthorizationHandlerContext context, SecurityLevelOrApiRequirement requirement)
         {
             logger.LogTrace("SecurityLevelClaimHandler: Validating");
+
+            if (!context.User.Identity?.IsAuthenticated ?? false)
+            {
+                logger.LogInformation("SecurityLevelClaimHandler: User is not authenticated, access denied");
+                return Task.CompletedTask;
+            }
+
             var securityLevelClaim = (context.User.FindFirst(c => c.Type.ToLowerInvariant() == IdentityClaims.SecurityLevel));
 
             if (securityLevelClaim != null)
@@ -36,7 +43,8 @@ namespace Fhi.HelseId.Web.Handlers
                 {
                     logger.LogError("SecurityLevelClaimHandler: Invalid security level claim '{securityLevelClaim}', access denied.", securityLevelClaim.Value);
                 }
-            } else
+            }
+            else
             {
                 logger.LogError("SecurityLevelClaimHandler: No security level claim found, access denied");
             }


### PR DESCRIPTION
**ApiMultiScopeHandler:** This class contained verbose logging that caused log files to become unreasonably large and hard to make sense of. This makes more sense to be enabled in a debugging context, so log level is set to Trace instead of Information. If we get an unauthorized response we will nevertheless log the claims as an error log event.

**SecurityLevelClaimHandler:** Do not validate if the user is not authenticated and log that no user is authenticated. Previously, if we sent a request with an empty authorization value or missing cookie, it would result in an error log event that no security level claim was found.